### PR TITLE
[BE] Add SpeardSheet Information

### DIFF
--- a/img2xl_app/models.py
+++ b/img2xl_app/models.py
@@ -2,50 +2,76 @@
 from __future__ import unicode_literals
 
 from django.db import models
-from djangae.fields import JSONField  # Import từ djangae
+from django.utils import timezone
+from django.contrib.auth.models import User
+from djangae.fields import ListField, JSONField  # Djangae support
+
 try:
     from djangae.db.models.fields import BlobField
 except ImportError:
-    # Nếu không tìm thấy, có thể dùng BinaryField mặc định của Django
     from django.db.models import BinaryField as BlobField
-from django.utils import timezone
-import json
-from django.contrib.auth.models import User  # Sử dụng User mặc định của Django
-from djangae.fields import JSONField
+
 
 class UploadedFile(models.Model):
+    """
+    Đóng vai trò là 'Media Library'.
+    Lưu trữ các ảnh đã upload, giới hạn 50 tấm/user.
+    """
     user = models.ForeignKey(User, on_delete=models.CASCADE, related_name='uploaded_files', null=True)
     filename = models.CharField(max_length=255)
     mime_type = models.CharField(max_length=100, blank=True, null=True)
-    image_url = models.TextField()  # Lưu binary trực tiếp vào Datastore
+    image_url = models.TextField()
     file_size = models.PositiveIntegerField(default=0)
     uploaded_at = models.DateTimeField(default=timezone.now)
-    is_deleted = models.BooleanField(default=False) # Dùng cho auto-cleanup #35
+
+    # Dùng để đánh dấu khi ảnh bị 'dọn dẹp' để nhường chỗ cho ảnh mới (tấm thứ 51)
+    is_deleted = models.BooleanField(default=False)
 
     def __unicode__(self):
         return u"%s (%s KB)" % (self.filename, self.file_size // 1024)
 
 
 class ExtractedResult(models.Model):
+    """
+    Đóng vai trò là 'Data Worksheet'.
+    Một bảng dữ liệu có thể được tạo từ 0, 1 hoặc nhiều ảnh.
+    """
     user = models.ForeignKey(User, on_delete=models.CASCADE, related_name='extraction_results', null=True)
-    uploaded_file = models.ForeignKey(UploadedFile, on_delete=models.CASCADE, related_name='extraction_results')
+
+    # TRƯỜNG MỚI: Tên bảng để người dùng dễ quản lý khi xem lịch sử
+    title = models.CharField(max_length=255, default="Bảng tính không tên")
+
+    # THAY ĐỔI QUAN TRỌNG:
+    # Lưu danh sách ID của các UploadedFile đã dùng để tạo ra bảng này.
+    # ListField([1, 2, 3]) cực kỳ nhẹ và tối ưu trên Datastore.
+    source_file_ids = ListField(models.IntegerField(), default=[], blank=True)
 
     status = models.CharField(max_length=20, default='pending')
-    is_draft = models.BooleanField(default=True)  # Trạng thái Draft/Final #38
+    is_draft = models.BooleanField(default=True)
+
     raw_response = models.TextField(blank=True, null=True)
     table_data_compressed = BlobField(blank=True, null=True)
-
-    # TRƯỜNG MỚI: Lưu bản nháp (Auto-save)
     table_data_draft = BlobField(blank=True, null=True)
 
     error_message = models.TextField(blank=True, null=True)
+    # Thời gian ấn Save Changes
     processed_at = models.DateTimeField(blank=True, null=True)
+    # Thời gian lưu lúc tạo
     created_at = models.DateTimeField(default=timezone.now)
-    updated_at = models.DateTimeField(auto_now=True)  # Lưu mốc thời gian auto-save #38
+    # Thời gian lưu bản draft
+    updated_at = models.DateTimeField(auto_now=True)
 
     def __unicode__(self):
-        filename = self.uploaded_file.filename if self.uploaded_file else "Unknown"
-        return u"%s - %s" % (filename, self.status)
+        return u"%s - %s" % (self.title, self.status)
+
+    def get_related_images(self):
+        """
+        Hàm tiện ích để lấy các object ảnh gốc từ Media Library.
+        Nếu ảnh đã bị xóa (do giới hạn 50 tấm), nó sẽ không xuất hiện trong kết quả.
+        """
+        if not self.source_file_ids:
+            return []
+        return UploadedFile.objects.filter(id__in=self.source_file_ids, is_deleted=False)
 
     def get_table(self, for_export=False):
         """Sử dụng OOP Handler để lấy dữ liệu"""
@@ -60,7 +86,7 @@ class ExtractedResult(models.Model):
 class UsageLog(models.Model):
     user = models.ForeignKey(User, on_delete=models.CASCADE, related_name='usage_logs')
     usage_date = models.DateField(default=timezone.now)
-    upload_count = models.IntegerField(default=0) # Số ảnh đã up trong ngày #35
+    upload_count = models.IntegerField(default=0)
 
     class Meta:
         unique_together = ('user', 'usage_date')

--- a/img2xl_app/services/table_handler.py
+++ b/img2xl_app/services/table_handler.py
@@ -12,6 +12,19 @@ class TableFileHandler(object):
     def __init__(self, result_instance):
         self.result = result_instance
 
+    def get_source_urls(self):
+        """Lấy danh sách URL của các ảnh liên quan để hiển thị trên UI"""
+        from ..models import UploadedFile
+        if not self.result.source_file_ids:
+            return []
+
+        # Lấy các file chưa bị xóa
+        files = UploadedFile.objects.filter(
+            id__in=self.result.source_file_ids,
+            is_deleted=False
+        )
+        return [f.image_url for f in files]
+
     def save_data(self, table_data, is_final=False):
         """
         is_final = False: Lưu vào bản Nháp (Auto-save)

--- a/img2xl_app/templates/documents.html
+++ b/img2xl_app/templates/documents.html
@@ -1,0 +1,117 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+    <meta charset="UTF-8">
+    <title>Quản lý tài liệu - Kiệt Trần Anh</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/sweetalert2@11/dist/sweetalert2.min.css">
+    <link rel="stylesheet" href="{% static 'css/documents.css' %}">
+</head>
+<body data-user-id="{{ request.user.id }}">
+    
+    {% include "includes/header.html" %}
+    
+    <div class="container-fluid mt-4 px-4 main-content">
+        <div id="bulk-actions-bar" class="alert alert-info d-none sticky-top" style="top: 70px; z-index: 1000;">
+            <div class="d-flex justify-content-between align-items-center">
+                <span>Đã chọn <strong id="selected-count">0</strong> tài liệu</span>
+                <div>
+                    <button class="btn btn-danger btn-sm" id="btn-bulk-delete"><i class="fas fa-trash"></i> Xóa các mục đã chọn</button>
+                    <button class="btn btn-secondary btn-sm" id="btn-cancel-select">Hủy</button>
+                </div>
+            </div>
+        </div>
+    
+        <div class="row align-items-center">
+            <div class="col-md-6"><h2>Kiệt Trần Anh</h2></div>
+        </div>
+    
+        <div class="d-flex justify-content-between align-items-center mt-4">
+            <h3 class="h4">Kiệt's Images</h3>
+            <button class="btn btn-success" id="btn-create-blank"><i class="fas fa-file-excel"></i> Tạo bảng tính trống</button>
+        </div>
+    
+        <div class="mt-3">
+            <div class="btn-group">
+                <a href="?sort=recent" class="btn btn-sm {% if current_sort == 'recent' %}btn-primary{% else %}btn-outline-primary{% endif %}">Recently</a>
+                <a href="?sort=oldest" class="btn btn-sm {% if current_sort == 'oldest' %}btn-primary{% else %}btn-outline-primary{% endif %}">Oldest</a>
+            </div>
+        </div>
+    
+        <hr>
+    
+        <div class="pad-content-listing mt-4">
+            <div class="row no-gutters">
+                {% for res in results %}
+                <div class="col-xl-2 col-lg-3 col-md-4 col-sm-6 mb-4 px-2">
+                    <div class="list-item jsly position-relative" data-id="{{ res.id }}" 
+                                                                 data-url="{{ res.uploaded_file.image_url }}"
+                                                                 data-filename="{{ res.uploaded_file.filename }}"
+                                                                 data-created="{{ res.processed_at|date:'d/m/Y H:i' }}"
+                                                                 data-updated="{{ res.updated_at|date:'d/m/Y H:i' }}"
+                                                                 data-spreadsheet-url="{% url 'result_detail' res.id %}">
+                        
+                        <div class="image-wrapper">
+                            <img src="{{ res.uploaded_file.image_url }}" class="img-main preview-trigger">
+    
+                            <div class="list-item-image-tools top-right">
+                                <div class="tool-select" title="Chọn"><span class="btn-icon fas fa-square icon-check"></span></div>
+                                <div class="tool-edit" title="Thông tin"><span class="btn-icon fas fa-info-circle"></span></div>
+                                <div class="tool-delete" title="Xóa"><span class="btn-icon fas fa-trash-alt"></span></div>
+                            </div>
+    
+                            <div class="list-item-image-tools --bottom --right">
+                                <div class="list-item-share" title="Copy Link"><span class="btn-icon fas fa-share-nodes"></span></div>
+                                <div class="list-item-like"><span class="btn-icon far fa-heart"></span></div>
+                            </div>
+                        </div>
+    
+                        <div class="list-item-desc">
+                            <div class="list-item-desc-title">
+                                <a href="{{ res.uploaded_file.image_url }}" class="list-item-desc-title-link text-truncate d-block" title="{{ res.uploaded_file.filename }}">
+                                    {{ res.uploaded_file.filename }}
+                                </a>
+                                <div class="info-date-group">
+                                    <div class="font-size-small text-muted">
+                                        <i class="far fa-calendar-alt"></i> Tạo: {{ res.processed_at|date:"d/m/Y H:i" }}
+                                    </div>
+                                    <div class="font-size-small text-primary">
+                                        <i class="fas fa-sync-alt"></i> Sửa: {{ res.updated_at|date:"d/m/Y H:i" }}
+                                    </div>
+                                </div>
+                                <div class="list-item-spreadsheet font-size-small mt-1">
+                                    <i class="fas fa-table text-success"></i> 
+                                    <a href="{% url 'result_detail' res.id %}" class="text-secondary font-weight-bold">
+                                        Mở bảng tính
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+    
+    <div class="modal fade" id="previewModal" tabindex="-1">
+        <div class="modal-dialog modal-xl modal-dialog-centered">
+            <div class="modal-content bg-transparent border-0">
+                <div class="modal-body text-center p-0">
+                    <img src="" id="modal-img-full" class="img-fluid rounded">
+                    <button type="button" class="btn btn-light mt-2" data-dismiss="modal">Đóng</button>
+                </div>
+            </div>
+        </div>
+    </div>
+    
+    {% include "includes/footer.html" %}
+    
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
+    <script src="{% static 'js/documents.js' %}"></script>
+</body>
+</html>

--- a/img2xl_app/templates/documents.html
+++ b/img2xl_app/templates/documents.html
@@ -8,107 +8,169 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/sweetalert2@11/dist/sweetalert2.min.css">
     <link rel="stylesheet" href="{% static 'css/documents.css' %}">
+    <link rel="stylesheet" href="{% static 'css/header.css' %}">
+    <link rel="stylesheet" href="{% static 'css/footer.css' %}">
 </head>
 <body data-user-id="{{ request.user.id }}">
-    
     {% include "includes/header.html" %}
-    
-    <div class="container-fluid mt-4 px-4 main-content">
-        <div id="bulk-actions-bar" class="alert alert-info d-none sticky-top" style="top: 70px; z-index: 1000;">
-            <div class="d-flex justify-content-between align-items-center">
-                <span>Đã chọn <strong id="selected-count">0</strong> tài liệu</span>
-                <div>
-                    <button class="btn btn-danger btn-sm" id="btn-bulk-delete"><i class="fas fa-trash"></i> Xóa các mục đã chọn</button>
-                    <button class="btn btn-secondary btn-sm" id="btn-cancel-select">Hủy</button>
-                </div>
-            </div>
-        </div>
-    
-        <div class="row align-items-center">
-            <div class="col-md-6"><h2>Kiệt Trần Anh</h2></div>
-        </div>
-    
-        <div class="d-flex justify-content-between align-items-center mt-4">
-            <h3 class="h4">Kiệt's Images</h3>
-            <button class="btn btn-success" id="btn-create-blank"><i class="fas fa-file-excel"></i> Tạo bảng tính trống</button>
-        </div>
-    
-        <div class="mt-3">
-            <div class="btn-group">
-                <a href="?sort=recent" class="btn btn-sm {% if current_sort == 'recent' %}btn-primary{% else %}btn-outline-primary{% endif %}">Recently</a>
-                <a href="?sort=oldest" class="btn btn-sm {% if current_sort == 'oldest' %}btn-primary{% else %}btn-outline-primary{% endif %}">Oldest</a>
-            </div>
-        </div>
-    
-        <hr>
-    
-        <div class="pad-content-listing mt-4">
-            <div class="row no-gutters">
-                {% for res in results %}
-                <div class="col-xl-2 col-lg-3 col-md-4 col-sm-6 mb-4 px-2">
-                    <div class="list-item jsly position-relative" data-id="{{ res.id }}" 
-                                                                 data-url="{{ res.uploaded_file.image_url }}"
-                                                                 data-filename="{{ res.uploaded_file.filename }}"
-                                                                 data-created="{{ res.processed_at|date:'d/m/Y H:i' }}"
-                                                                 data-updated="{{ res.updated_at|date:'d/m/Y H:i' }}"
-                                                                 data-spreadsheet-url="{% url 'result_detail' res.id %}">
-                        
-                        <div class="image-wrapper">
-                            <img src="{{ res.uploaded_file.image_url }}" class="img-main preview-trigger">
-    
-                            <div class="list-item-image-tools top-right">
-                                <div class="tool-select" title="Chọn"><span class="btn-icon fas fa-square icon-check"></span></div>
-                                <div class="tool-edit" title="Thông tin"><span class="btn-icon fas fa-info-circle"></span></div>
-                                <div class="tool-delete" title="Xóa"><span class="btn-icon fas fa-trash-alt"></span></div>
-                            </div>
-    
-                            <div class="list-item-image-tools --bottom --right">
-                                <div class="list-item-share" title="Copy Link"><span class="btn-icon fas fa-share-nodes"></span></div>
-                                <div class="list-item-like"><span class="btn-icon far fa-heart"></span></div>
-                            </div>
+
+    <div class="container-fluid mt-4 px-4">
+        <div class="row mb-4">
+            <div class="col-12">
+                <div class="card bg-light border-0 shadow-sm">
+                    <div class="card-body py-3 d-flex align-items-center justify-content-between">
+                        <div>
+                            <h5 class="mb-1 font-weight-bold"><i class="fas fa-cloud-upload-alt mr-2 text-primary"></i>Kho lưu trữ ảnh</h5>
+                            <p class="small text-muted mb-0">Bạn đã sử dụng {{ extractedResult }} / 50 tấm ảnh cho phép.</p>
                         </div>
-    
-                        <div class="list-item-desc">
-                            <div class="list-item-desc-title">
-                                <a href="{{ res.uploaded_file.image_url }}" class="list-item-desc-title-link text-truncate d-block" title="{{ res.uploaded_file.filename }}">
-                                    {{ res.uploaded_file.filename }}
-                                </a>
-                                <div class="info-date-group">
-                                    <div class="font-size-small text-muted">
-                                        <i class="far fa-calendar-alt"></i> Tạo: {{ res.processed_at|date:"d/m/Y H:i" }}
-                                    </div>
-                                    <div class="font-size-small text-primary">
-                                        <i class="fas fa-sync-alt"></i> Sửa: {{ res.updated_at|date:"d/m/Y H:i" }}
-                                    </div>
-                                </div>
-                                <div class="list-item-spreadsheet font-size-small mt-1">
-                                    <i class="fas fa-table text-success"></i> 
-                                    <a href="{% url 'result_detail' res.id %}" class="text-secondary font-weight-bold">
-                                        Mở bảng tính
-                                    </a>
-                                </div>
-                            </div>
+                        <div class="progress w-25" style="height: 10px;">
+                            <div class="progress-bar {% if extractedResult > 40 %}bg-danger{% else %}bg-success{% endif %}"
+                                 role="progressbar" style="width: {% widthratio extractedResult 50 100 %}%"></div>
                         </div>
                     </div>
                 </div>
-                {% endfor %}
             </div>
         </div>
-    </div>
-    
-    <div class="modal fade" id="previewModal" tabindex="-1">
-        <div class="modal-dialog modal-xl modal-dialog-centered">
-            <div class="modal-content bg-transparent border-0">
-                <div class="modal-body text-center p-0">
-                    <img src="" id="modal-img-full" class="img-fluid rounded">
-                    <button type="button" class="btn btn-light mt-2" data-dismiss="modal">Đóng</button>
+
+        <hr>
+
+        <div id="bulk-actions-bar" class="">
+            <div class="d-flex justify-content-between align-items-center w-100">
+                <span class="mb-0">Đã chọn <strong id="selected-count">0</strong> ảnh</span>
+                <div class="d-flex align-items-center">
+                    <button class="btn btn-danger btn-sm rounded-pill px-3 mr-2" id="btn-bulk-delete">
+                        <i class="fas fa-trash mr-1"></i> Xóa các mục đã chọn
+                    </button>
+                    <button class="btn btn-light btn-sm rounded-pill px-3" id="btn-cancel-select">
+                        Hủy
+                    </button>
+                </div>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-lg-3 col-custom-20">
+                <div class="d-flex justify-content-between align-items-center mb-3">
+                    <h5 class="mb-0 font-weight-bold">Bảng tính</h5>
+                    <div class="btn-group btn-group-sm w-100 mb-2">
+                        <button class="btn btn-sort-sidebar {% if current_sort != 'created' and current_sort != 'oldest' %}btn-secondary text-white{% else %}btn-outline-secondary{% endif %}" 
+                                data-sort="updated">
+                            Gần đây
+                        </button>
+                    
+                        <button class="btn btn-sort-sidebar {% if current_sort == 'created' %}btn-secondary text-white{% else %}btn-outline-secondary{% endif %}" 
+                                data-sort="created">
+                            Mới nhất
+                        </button>
+                    
+                        <button class="btn btn-sort-sidebar {% if current_sort == 'oldest' %}btn-secondary text-white{% else %}btn-outline-secondary{% endif %}" 
+                                data-sort="old">
+                            Cũ nhất
+                        </button>
+                    </div>
+                </div>
+
+                <div class="list-group sidebar-spreadsheets" id="sidebar-list">
+                    <div class="list-group-item list-group-item-action active spreadsheet-filter" data-id="all">
+                        <i class="fas fa-th-large mr-2"></i> <strong>Tất cả hình ảnh</strong>
+                    </div>
+
+                    {% for res in results %}
+                    <div class="list-group-item list-group-item-action spreadsheet-filter-item" 
+                         data-id="{{ res.id }}" 
+                         data-created="{{ res.created_at|date:'U' }}"
+                         data-updated="{{ res.updated_at|date:'U' }}">
+                        <div class="d-flex justify-content-between align-items-start">
+                            <div class="spreadsheet-click-area flex-grow-1">
+                                <a href="{% url 'result_detail' res.id %}" class="spreadsheet-title-link">
+                                    <i class="fas fa-file-excel text-success mr-2"></i>
+                                    <span class="title-text">{{ res.title }}</span>
+                                </a>
+                                <div class="small text-muted mt-1">
+                                    <div><i class="far fa-calendar-alt"></i> Tạo: {{ res.created_at|date:'d/m/Y' }}</div>
+                                    <div><i class="fas fa-history"></i> Sửa: {{ res.updated_at|date:'d/m/Y' }}</div>
+                                </div>
+                            </div>
+                            <div class="spreadsheet-actions">
+                                <button class="btn btn-link btn-sm p-0 text-info btn-edit-title" data-id="{{ res.id }}" data-title="{{ res.title }}">
+                                    <i class="fas fa-edit"></i>
+                                </button>
+                                <button class="btn btn-link btn-sm p-0 text-danger btn-delete-res ml-2" data-id="{{ res.id }}">
+                                    <i class="fas fa-trash"></i>
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                    {% endfor %}
+                </div>
+            </div>
+
+            <div class="col-lg-9 col-custom-80 border-left">
+                <div class="d-flex justify-content-between align-items-center mb-4">
+                    <h4 class="mb-0 font-weight-bold" id="gallery-header">Tất cả hình ảnh</h4>
+                    <div class="d-flex align-items-center">
+                        <span class="mr-2 small text-muted">Sắp xếp ảnh:</span>
+                        <div class="btn-group btn-group-sm">
+                            <button class="btn btn-primary btn-sort-gallery" data-sort="new">Mới nhất</button>
+                            <button class="btn btn-outline-primary btn-sort-gallery" data-sort="old">Cũ nhất</button>
+                        </div>
+                        <button class="btn btn-success btn-sm ml-3" id="btn-create-blank"><i class="fas fa-plus"></i> Tạo bảng</button>
+                    </div>
+                </div>
+
+                <div class="row no-gutters" id="image-gallery">
+                    {% for img in all_images %}
+                        <div class="col-xl-2 col-lg-3 col-md-4 col-sm-6 mb-4 px-2 gallery-card"
+                             data-timestamp="{{ img.uploaded_at|date:'U' }}"
+                             {% if results %}
+                                {# Tìm xem ảnh này thuộc bảng nào trong danh sách kết quả #}
+                                data-spreadsheet-id="{% for res in results %}{% if img.id in res.source_file_ids %}{{ res.id }} {% endif %}{% endfor %}"
+                             {% endif %}
+                             data-img-id="{{ img.id }}"
+                             data-filename="{{ img.filename }}"
+                             data-mime="{{ img.mime_type }}"
+                             data-url="{{ img.image_url }}"
+                             data-size="{{ img.file_size }}"
+                             data-uploaded="{{ img.uploaded_at|date:'d/m/Y H:i' }}">
+
+                            <div class="list-item shadow-sm">
+                                <div class="image-wrapper">
+                                    <img src="{{ img.image_url }}" class="img-main preview-trigger">
+
+                                    <div class="list-item-image-tools top-right">
+                                        <div class="tool-img-info" title="Xem chi tiết">
+                                            <span class="btn-icon fas fa-info-circle"></span>
+                                        </div>
+                                        <div class="tool-img-select" title="Chọn ảnh">
+                                            <span class="btn-icon fas fa-square icon-check-img"></span>
+                                        </div>
+                                        <div class="tool-img-delete" title="Xóa ảnh">
+                                            <span class="btn-icon fas fa-trash-alt"></span>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="list-item-desc p-2">
+                                    <div class="text-truncate font-weight-bold small mb-1" title="{{ img.filename }}">
+                                        <a href="{{ img.image_url }}" target="_blank" class="text-dark text-decoration-none">
+                                            {{ img.filename }}
+                                        </a>
+                                    </div>
+                                    <div class="font-size-small text-muted">
+                                        <i class="far fa-clock"></i> {{ img.uploaded_at|date:"d/m/Y H:i" }}
+                                    </div>
+                                    <div class="font-size-small text-primary mt-1">
+                                        <i class="fas fa-link"></i> {{ res.title }}
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        {% endfor %}
                 </div>
             </div>
         </div>
     </div>
-    
+
     {% include "includes/footer.html" %}
-    
+
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>

--- a/img2xl_app/templates/home.html
+++ b/img2xl_app/templates/home.html
@@ -46,7 +46,7 @@
                                     {% for res in recent_results %}
                                         <li class="history-item d-flex justify-content-between align-items-center" id="item-{{ res.id }}">
                                             <a href="{% url 'result_detail' res.id %}" class="text-truncate flex-grow-1">
-                                                <i class="far fa-file-image mr-2"></i>{{ res.uploaded_file.filename|truncatechars:15 }}
+                                                <i class="far fa-file-image mr-2"></i>{{ res.title|truncatechars:15 }}
                                             </a>
                                             
                                             <div class="d-flex align-items-center">

--- a/img2xl_app/templates/includes/header.html
+++ b/img2xl_app/templates/includes/header.html
@@ -16,7 +16,7 @@
                              <i class="fas fa-user-circle mr-1"></i> {{ user.username }}
                         </a>
                         <div class="dropdown-menu dropdown-menu-right shadow border-0" aria-labelledby="userDropdown">
-                            <a class="dropdown-item py-2" href="{% url 'profile' %}">
+                            <a class="dropdown-item py-2" href="{% url 'documents' %}">
                                 <i class="fas fa-id-card mr-2 text-muted"></i> Hồ sơ của tôi
                             </a>
                             <a class="dropdown-item py-2" href="{% url 'settings' %}">

--- a/img2xl_app/templates/includes/header.html
+++ b/img2xl_app/templates/includes/header.html
@@ -17,7 +17,7 @@
                         </a>
                         <div class="dropdown-menu dropdown-menu-right shadow border-0" aria-labelledby="userDropdown">
                             <a class="dropdown-item py-2" href="{% url 'documents' %}">
-                                <i class="fas fa-id-card mr-2 text-muted"></i> Hồ sơ của tôi
+                                <i class="fas fa-id-card mr-2 text-muted"></i> Tài liệu của tôi
                             </a>
                             <a class="dropdown-item py-2" href="{% url 'settings' %}">
                                 <i class="fas fa-user-cog mr-2 text-muted"></i> Cài đặt

--- a/img2xl_app/templates/result_detail.html
+++ b/img2xl_app/templates/result_detail.html
@@ -29,8 +29,8 @@
             <div class="info-box left-side shadow-sm mb-3">
                 <h4 class="box-title">File Details</h4>
                 <div class="small">
-                    <p class="mb-1 text-truncate" title="{{ result.uploaded_file.filename }}">
-                        <strong>Name:</strong> <a href="{{ result.uploaded_file.image_url }}" target="_blank" class="filename-link">{{ result.uploaded_file.filename }}</a>
+                    <p class="mb-1 text-truncate" title="{{ result.title }}">
+                        <strong>Name:</strong> <a target="_blank" class="filename-link">{{ result.title }}</a>
                     </p>
                     <p class="mb-1"><strong>Status:</strong> <span class="badge badge-primary">{{ result.status|title }}</span></p>
                     <p class="mb-0 text-muted">Processed: {{ result.processed_at|date:"d/m H:i" }}</p>
@@ -44,7 +44,7 @@
                         {% for res in recent_results %}
                             <li class="history-item {% if res.id == result.id %}active{% endif %}">
                                 <a href="{% url 'result_detail' res.id %}" class="d-block text-truncate">
-                                    <i class="far fa-file-alt mr-1"></i> {{ res.uploaded_file.filename|truncatechars:20 }}
+                                    <i class="far fa-file-alt mr-1"></i> {{ res.title|truncatechars:50 }}
                                 </a>
                             </li>
                         {% endfor %}
@@ -133,6 +133,7 @@
         window.DJANGO_TABLE_DATA = {{ table_json|safe }};
         window.FINAL_TABLE_DATA = {{ final_table_json|safe }};
         window.DJANGO_SAVE_URL = "{% url 'update_table_data' result.id %}";
+        window.CURRENT_RESULT_ID = "{{ result.id }}";
     </script>
     <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.bundle.min.js"></script>

--- a/img2xl_app/urls.py
+++ b/img2xl_app/urls.py
@@ -17,6 +17,7 @@ urlpatterns = [
     url(r'^api/generate-ai-content/$', views.ai_generate_view, name='ai_generate_view'),
     url(r'^extract-only-api/$', views.extract_only_api, name='extract_only_api'),
     url(r'^tasks/cleanup/$', views.cleanup_old_data, name='cleanup_old_data'),
-    url(r'^profile/$', views.profile_view, name='profile'),
+    url(r'^documents/$', views.documents_view, name='documents'),
     url(r'^settings/$', views.settings_view, name='settings'),
+    url(r'^documents/create-blank/$', views.create_blank_document, name='create_blank_document'),
 ]

--- a/img2xl_app/urls.py
+++ b/img2xl_app/urls.py
@@ -12,7 +12,7 @@ urlpatterns = [
     url(r'^result/(?P<result_id>\d+)/$', views.result_detail, name='result_detail'),
     url(r'^delete/(?P<result_id>\d+)/$', views.delete_result, name='delete_result'),
     url(r'^export/(?P<result_id>\d+)/$', views.export, name='export'),
-    url(r'^export/(?P<result_id>\d+)/$', views.export_to_sheets, name='export_to_sheets'),
+    url(r'^export_to_sheets/(?P<result_id>\d+)/$', views.export_to_sheets, name='export_to_sheets'),
     url(r'^result/(?P<result_id>\d+)/update/$', views.update_table_data, name='update_table_data'),
     url(r'^api/generate-ai-content/$', views.ai_generate_view, name='ai_generate_view'),
     url(r'^extract-only-api/$', views.extract_only_api, name='extract_only_api'),
@@ -20,4 +20,12 @@ urlpatterns = [
     url(r'^documents/$', views.documents_view, name='documents'),
     url(r'^settings/$', views.settings_view, name='settings'),
     url(r'^documents/create-blank/$', views.create_blank_document, name='create_blank_document'),
+
+    # 1. API cho Bảng tính từ documents.js (ExtractedResult)
+    url(r'^api/update-title/(?P<result_id>\d+)/$', views.update_title_api, name='update_title_api'),
+    url(r'^api/delete-result/(?P<result_id>\d+)/$', views.delete_result_api, name='delete_result_api'),
+
+    # 2. API cho Hình ảnh từ documents.js (UploadedFile)
+    url(r'^api/delete-image/(?P<img_id>\d+)/$', views.delete_image_api, name='delete_image_api'),
+    url(r'^api/bulk-delete-images/$', views.bulk_delete_images_api, name='bulk_delete_images_api'),
 ]

--- a/img2xl_app/views.py
+++ b/img2xl_app/views.py
@@ -500,11 +500,85 @@ def _export_png(result, table_data, bg_color, start_cell, num_rows, num_cols):
     return response
 
 @login_required
-def profile_view(request):
+def documents_view(request):
     # Tạm thời để trống như yêu cầu
-    return render(request, 'profile.html')
+    return render(request, 'documents.html')
 
 @login_required
 def settings_view(request):
     # Trả về trang settings, dữ liệu user đã có sẵn trong request.user
     return render(request, 'settings.html')
+
+#documents.html
+@login_required
+def documents_view(request):
+    sort = request.GET.get('sort', 'recent')
+    user = request.user
+
+    # Lấy danh sách kết quả của user
+    results_query = ExtractedResult.objects.filter(user=user)
+
+    # Đếm tổng số documents
+    extracted_count = results_query.count()
+
+    # Logic sắp xếp
+    if sort == 'oldest':
+        results = results_query.order_by('processed_at')
+    else:
+        results = results_query.order_by('-updated_at')
+
+    return render(request, 'documents.html', {
+        'results': results,
+        'extractedResult': extracted_count,
+        'current_sort': sort
+    })
+
+@login_required
+@require_POST
+def create_blank_document(request):
+    """Tạo một ExtractedResult với dữ liệu trống"""
+    name = request.POST.get('name', 'Untitled Spreadsheet')
+    user = request.user
+
+    # 1. Tạo UploadedFile giả lập
+    uf = UploadedFile.objects.create(
+        user=user,
+        filename=name + ".xlsx",
+        image_url="https://via.placeholder.com/800x600.png?text=Blank+Document",  # Ảnh tạm
+        file_size=0
+    )
+
+    # 2. Tạo ExtractedResult
+    res_obj = ExtractedResult.objects.create(
+        user=user,
+        uploaded_file=uf,
+        status='success',
+        is_draft=True
+    )
+
+    # 3. Khởi tạo bảng trống (VD: 5 hàng x 5 cột)
+    empty_data = [["" for _ in range(5)] for _ in range(5)]
+    handler = TableFileHandler(res_obj)
+    handler.save_data(empty_data)
+
+    return JsonResponse({'status': 'success', 'redirect_url': reverse('result_detail', args=[res_obj.id])})
+
+
+@login_required
+@require_POST
+def bulk_delete_api(request):
+    """Xóa hàng loạt IDs"""
+    ids = json.loads(request.body).get('ids', [])
+    results = ExtractedResult.objects.filter(id__in=ids, user=request.user)
+
+    count = 0
+    for res in results:
+        # Xóa file vật lý qua handler
+        handler = TableFileHandler(res)
+        handler.delete_file()
+        # Xóa DB
+        res.uploaded_file.delete()
+        res.delete()
+        count += 1
+
+    return JsonResponse({'status': 'success', 'deleted_count': count})

--- a/img2xl_app/views.py
+++ b/img2xl_app/views.py
@@ -178,18 +178,39 @@ def export_to_sheets(request, result_id):
 
 def delete_result(request, result_id):
     if request.method == 'POST':
-        result = get_object_or_404(ExtractedResult, id=result_id)
+        # Thêm filter user=request.user để đảm bảo tính bảo mật
+        result = get_object_or_404(ExtractedResult, id=result_id, user=request.user)
 
-        # Khởi tạo Handler và dọn dẹp file vật lý trước
-        handler = TableFileHandler(result.id)
-        handler.delete_file()
+        # 1. Khởi tạo Handler để dọn dẹp file vật lý (file .xlsx hoặc .csv lưu trên storage)
+        # Theo models.py của bạn, TableFileHandler nhận vào nguyên object 'result'
+        try:
+            handler = TableFileHandler(result)
+            handler.delete_file()
+        except Exception as e:
+            # Nếu không tìm thấy file vật lý để xóa thì vẫn tiếp tục xóa DB
+            pass
 
-        # Sau đó mới xóa Database
-        result.uploaded_file.delete()
+        # 2. XÓA DÒNG NÀY: result.uploaded_file.delete()
+        # Vì ExtractedResult không còn thuộc tính uploaded_file nữa.
+
+        # 3. Xóa bản ghi bảng tính trong Database
+        # Các ảnh liên quan (UploadedFile) sẽ KHÔNG bị ảnh hưởng vì chúng là các record độc lập
         result.delete()
 
     return redirect('home')
 
+
+def is_storage_full(user):
+    """
+    Hàm helper kiểm tra xem user đã đạt giới hạn 50 ảnh chưa.
+    Trả về True nếu đã đầy, False nếu còn chỗ.
+    """
+    if not user.is_authenticated():
+        return False  # Hoặc xử lý riêng cho khách (Guest)
+
+    # Đếm số file đang hoạt động (chưa bị xóa) của user
+    current_count = UploadedFile.objects.filter(user=user, is_deleted=False).count()
+    return current_count >= 50
 
 @require_POST
 def update_table_data(request, result_id):
@@ -258,64 +279,90 @@ def ai_generate_view(request):
 
     return JsonResponse({'status': 'error', 'message': 'Invalid Method'})
 
+
+# views.py
+
 @require_POST
 def extract_only_api(request):
     user = request.user
-    if 'file' not in request.FILES:
-        return JsonResponse({'status': 'error', 'message': u'Chưa chọn file.'})
+    if not user.is_authenticated():
+        return JsonResponse({'status': 'error', 'message': u'Vui lòng đăng nhập.'}, status=401)
 
-    # Đọc tham số 'save_db' từ FormData (mặc định là false)
-    # Vì FormData gửi lên là string nên ta so sánh với 'true'
-    should_save = request.POST.get('save_db') == 'true'
+    # 1. KIỂM TRA HẠN MỨC 50 ẢNH (Luôn kiểm tra vì bước nào cũng lưu vết ảnh)
+    if is_storage_full(user):
+        return JsonResponse({
+            'status': 'limit_exceeded',
+            'message': u'Kho lưu trữ ảnh đã đầy (50/50). Hãy xóa bớt ảnh cũ.',
+            'redirect_url': reverse('documents_view')
+        }, status=403)
 
-    # Đọc tham số 'languages' từ FormData (nếu không có thì mặc định là 'all')
+    # 2. ĐỌC THAM SỐ TỪ FRONTEND
+    # save_db=true: Tạo bảng mới (Home) | save_db=false: Cập nhật bảng hiện tại (Detail)
+    is_create_new = request.POST.get('save_db') == 'true'
+    current_result_id = request.POST.get('result_id')  # ID bảng đang mở (nếu có)
     languages = request.POST.get('languages', 'all')
+    mime_type = request.POST.get('mime_type', 'image/jpeg')
 
-    # 1. Logic trích xuất AI dùng chung
+    if 'file' not in request.FILES:
+        return JsonResponse({'status': 'error', 'message': u'Chưa có file.'})
+
     uploaded_file = request.FILES['file']
 
-    table_data, image_url, error = _perform_extraction_logic(uploaded_file, languages)
+    imgname = request.POST.get('original_filename', uploaded_file.name)
 
+    # 3. THỰC HIỆN OCR
+    table_data, image_url, error = _perform_extraction_logic(uploaded_file, languages)
     if error:
         return JsonResponse({'status': 'error', 'message': error})
 
-    # 2. CHỈ LƯU NẾU CÓ YÊU CẦU (Dành cho trang Home)
-    if should_save:
-        now_str = timezone.now().strftime('%Y%m%d_%H%M%S')
-        uf = UploadedFile.objects.create(
-            user=user if user.is_authenticated() else None,
-            filename="IMG_%s.jpg" % now_str,
-            mime_type='image/jpeg',
-            image_url=image_url,
-            file_size=uploaded_file.size
-        )
+    # 4. LUÔN LƯU VẾT ẢNH (UPLOADEDFILE) - Bất kể tạo mới hay cập nhật
+    uf = UploadedFile.objects.create(
+        user=user,
+        filename=imgname,
+        mime_type=mime_type,
+        image_url=image_url,
+        file_size=uploaded_file.size
+    )
 
+    # Cập nhật UsageLog
+    usage, _ = UsageLog.objects.get_or_create(user=user, usage_date=timezone.now().date())
+    usage.upload_count += 1
+    usage.save()
+
+    # 5. XỬ LÝ EXTRACTEDRESULT (BẢNG DỮ LIỆU)
+    res_obj = None
+
+    if is_create_new:
+        # FLOW 1: TỪ TRANG CHỦ -> TẠO BẢNG MỚI
         res_obj = ExtractedResult.objects.create(
-            user=user if user.is_authenticated() else None,
-            uploaded_file=uf,
+            user=user,
+            title=u"Bảng tạo từ " + uf.filename,
+            source_file_ids=[uf.id],
             status='success',
-            processed_at=timezone.now()
+            processed_at=timezone.now()  # Đánh dấu đã có bản Final đầu tiên
         )
-
+        # Lưu vào cả Draft và Final
         handler = TableFileHandler(res_obj)
-        handler.save_data(table_data)
+        handler.save_data(table_data, is_final=True)
 
-        if user.is_authenticated():
-            usage, _ = UsageLog.objects.get_or_create(user=user, usage_date=timezone.now().date())
-            usage.upload_count += 1
-            usage.save()
+    elif current_result_id:
+        # FLOW 2: TRONG BẢNG CHI TIẾT -> CHỈ CẬP NHẬT DRAFT
+        res_obj = get_object_or_404(ExtractedResult, id=current_result_id, user=user)
 
-        return JsonResponse({
-            'status': 'success',
-            'result_id': res_obj.id, # Trả về ID để chuyển trang
-            'table': table_data
-        })
+        # Thêm ID ảnh mới vào danh sách lưu vết của bảng
+        if uf.id not in res_obj.source_file_ids:
+            res_obj.source_file_ids.append(uf.id)
+            res_obj.save()
 
-    # 3. NẾU KHÔNG LƯU (Dành cho trang Detail)
-    # Chỉ trả về dữ liệu bảng thô
+        # CHỈ cập nhật bản Nháp (Draft), không đè lên bản Chính (Final)
+        # Người dùng có thể xóa data này đi, nhưng ID ảnh trong source_file_ids vẫn còn
+        handler = TableFileHandler(res_obj)
+        handler.save_data(table_data, is_final=False)
+
     return JsonResponse({
         'status': 'success',
-        'table': table_data
+        'result_id': res_obj.id if res_obj else None,
+        'table': table_data  # Trả về để JS hiển thị lên bảng
     })
 
 def register(request):
@@ -500,11 +547,6 @@ def _export_png(result, table_data, bg_color, start_cell, num_rows, num_cols):
     return response
 
 @login_required
-def documents_view(request):
-    # Tạm thời để trống như yêu cầu
-    return render(request, 'documents.html')
-
-@login_required
 def settings_view(request):
     # Trả về trang settings, dữ liệu user đã có sẵn trong request.user
     return render(request, 'settings.html')
@@ -515,48 +557,44 @@ def documents_view(request):
     sort = request.GET.get('sort', 'recent')
     user = request.user
 
-    # Lấy danh sách kết quả của user
+    # 1. Lấy danh sách bảng tính (dùng cho Sidebar 20%)
     results_query = ExtractedResult.objects.filter(user=user)
 
-    # Đếm tổng số documents
-    extracted_count = results_query.count()
+    # 2. Lấy TOÀN BỘ ảnh của user (dùng cho Gallery 80%)
+    # Điều này đảm bảo ảnh vẫn hiện dù bảng tính bị xóa
+    all_images_query = UploadedFile.objects.filter(user=user, is_deleted=False)
 
-    # Logic sắp xếp
+    # Logic sắp xếp cho bảng tính
     if sort == 'oldest':
-        results = results_query.order_by('processed_at')
+        results = results_query.order_by('created_at')
+        all_images = all_images_query.order_by('uploaded_at')
     else:
         results = results_query.order_by('-updated_at')
+        all_images = all_images_query.order_by('-uploaded_at')
 
     return render(request, 'documents.html', {
-        'results': results,
-        'extractedResult': extracted_count,
+        'results': results,  # Dùng cho sidebar
+        'all_images': all_images,  # Dùng cho gallery ảnh
+        'extractedResult': all_images.count(),  # Đếm ảnh thay vì đếm bảng
         'current_sort': sort
     })
 
 @login_required
 @require_POST
 def create_blank_document(request):
-    """Tạo một ExtractedResult với dữ liệu trống"""
+    """Tạo bảng trống - KHÔNG cần tạo UploadedFile giả nữa"""
     name = request.POST.get('name', 'Untitled Spreadsheet')
     user = request.user
 
-    # 1. Tạo UploadedFile giả lập
-    uf = UploadedFile.objects.create(
-        user=user,
-        filename=name + ".xlsx",
-        image_url="https://via.placeholder.com/800x600.png?text=Blank+Document",  # Ảnh tạm
-        file_size=0
-    )
-
-    # 2. Tạo ExtractedResult
+    # Tạo thẳng ExtractedResult với source_file_ids rỗng
     res_obj = ExtractedResult.objects.create(
         user=user,
-        uploaded_file=uf,
+        title=name,
+        source_file_ids=[], # Bảng trống
         status='success',
         is_draft=True
     )
 
-    # 3. Khởi tạo bảng trống (VD: 5 hàng x 5 cột)
     empty_data = [["" for _ in range(5)] for _ in range(5)]
     handler = TableFileHandler(res_obj)
     handler.save_data(empty_data)
@@ -566,19 +604,77 @@ def create_blank_document(request):
 
 @login_required
 @require_POST
-def bulk_delete_api(request):
-    """Xóa hàng loạt IDs"""
-    ids = json.loads(request.body).get('ids', [])
-    results = ExtractedResult.objects.filter(id__in=ids, user=request.user)
+def update_title_api(request, result_id):
+    """API: Đổi tên bảng tính"""
+    result = get_object_or_404(ExtractedResult, id=result_id, user=request.user)
+    new_title = request.POST.get('title')
 
-    count = 0
-    for res in results:
-        # Xóa file vật lý qua handler
-        handler = TableFileHandler(res)
+    if new_title:
+        result.title = new_title
+        result.save()
+        return JsonResponse({'status': 'success'})
+
+    return JsonResponse({'status': 'error', 'message': 'Thiếu tiêu đề'}, status=400)
+
+
+@login_required
+@require_POST
+def delete_result_api(request, result_id):
+    """API: Xóa bảng tính nhưng GIỮ LẠI hình ảnh"""
+    result = get_object_or_404(ExtractedResult, id=result_id, user=request.user)
+
+    # Dọn dẹp file vật lý trước
+    try:
+        # Dựa theo get_table trong model, Handler nhận object (result) chứ không phải result.id
+        handler = TableFileHandler(result)
         handler.delete_file()
-        # Xóa DB
-        res.uploaded_file.delete()
-        res.delete()
-        count += 1
+    except Exception as e:
+        # Nếu không có file hoặc có lỗi vật lý, vẫn tiếp tục xóa trong database
+        pass
 
-    return JsonResponse({'status': 'success', 'deleted_count': count})
+    # Xóa record trong Database
+    # Vì source_file_ids chỉ là ListField chứa ID (số nguyên) chứ không phải ForeignKey,
+    # việc gọi result.delete() hoàn toàn KHÔNG tự động xóa ảnh trong UploadedFile.
+    result.delete()
+
+    return JsonResponse({'status': 'success'})
+
+
+@login_required
+@require_POST
+def delete_image_api(request, img_id):
+    """API: Xóa 1 ảnh (UploadedFile)"""
+    image = get_object_or_404(UploadedFile, id=img_id, user=request.user)
+
+    # Xóa ảnh vật lý (nếu bạn có lưu file trên Storage) - Thêm code của bạn ở đây nếu cần
+    # ...
+
+    # Xóa trong database.
+    # Như bạn yêu cầu, hành động này không ảnh hưởng đến ListField `source_file_ids`
+    # của bảng ExtractedResult. ID cũ vẫn sẽ nằm đó để bạn chạy script cleanup sau.
+    image.delete()
+
+    return JsonResponse({'status': 'success'})
+
+
+@login_required
+@require_POST
+def bulk_delete_images_api(request):
+    """API: Xóa nhiều ảnh cùng lúc"""
+    try:
+        # Lấy dữ liệu JSON từ request.body (do JS gửi bằng JSON.stringify)
+        data = json.loads(request.body)
+        ids = data.get('ids', [])
+
+        if ids:
+            # Xóa trên Storage (nếu có) trước khi xóa DB
+            # images_to_delete = UploadedFile.objects.filter(id__in=ids, user=request.user)
+            # for img in images_to_delete:
+            #     # Thực hiện xóa file vật lý
+
+            # Xóa hàng loạt trong Database (rất nhanh và tối ưu)
+            UploadedFile.objects.filter(id__in=ids, user=request.user).delete()
+
+        return JsonResponse({'status': 'success'})
+    except ValueError:  # Bắt lỗi parse JSON
+        return JsonResponse({'status': 'error', 'message': 'Dữ liệu không hợp lệ'}, status=400)

--- a/index.yaml
+++ b/index.yaml
@@ -29,6 +29,17 @@ indexes:
   - name: created_at
     direction: desc
 
+- kind: img2xl_app_extractedresult
+  properties:
+  - name: user_id
+  - name: processed_at
+
+- kind: img2xl_app_extractedresult
+  properties:
+  - name: user_id
+  - name: updated_at
+    direction: desc
+
 - kind: img2xl_app_uploadedfile
   properties:
   - name: user_id

--- a/index.yaml
+++ b/index.yaml
@@ -42,6 +42,13 @@ indexes:
 
 - kind: img2xl_app_uploadedfile
   properties:
+  - name: is_deleted
+  - name: user_id
+  - name: uploaded_at
+    direction: desc
+
+- kind: img2xl_app_uploadedfile
+  properties:
   - name: user_id
   - name: uploaded_at
     direction: desc

--- a/static/css/documents.css
+++ b/static/css/documents.css
@@ -1,0 +1,174 @@
+body {
+    padding-top: 80px;
+    background-color: #f4f7f6;
+}
+
+/* Container chính */
+.pad-content-listing {
+    width: 100%;
+    min-height: 1400px;
+}
+
+/* Wrapper cho ảnh để quản lý overlay */
+.image-wrapper {
+    position: relative;
+    background: #eee;
+    border-radius: 4px;
+    overflow: hidden;
+    aspect-ratio: 1 / 1; /* Giữ ảnh vuông hoặc tỉ lệ nhất định */
+}
+
+.img-main {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+/* Tools chung */
+.list-item-image-tools {
+    position: absolute;
+    top: 0;
+    right: 0;
+    display: flex;
+    background: rgba(0, 0, 0, 0.5);
+    padding: 5px;
+    opacity: 0;
+    transition: opacity 0.2s ease-in-out;
+}
+
+/* Hiện tools khi hover */
+.list-item:hover .list-item-image-tools {
+    opacity: 1;
+}
+
+/* Tool ở dưới */
+.list-item-image-tools.--bottom {
+    top: auto;
+    bottom: 0;
+}
+
+.btn-icon {
+    color: white;
+    cursor: pointer;
+    transition: color 0.2s;
+}
+.btn-icon:hover {
+    color: #3498db;
+}
+
+/* Mô tả dưới ảnh */
+.list-item-desc {
+    padding: 8px 2px;
+}
+
+.list-item-desc-title-link {
+    font-weight: 600;
+    font-size: 13px;
+    color: #333;
+    text-decoration: none;
+}
+
+.font-size-small {
+    font-size: 11px;
+    color: #777;
+}
+
+/* Responsive Grid 6 cột */
+@media (min-width: 1200px) {
+    .col-xl-2 {
+        flex: 0 0 16.666667%;
+        max-width: 16.666667%;
+    }
+}
+
+/* Custom cho nút Like đã nhấn */
+.btn-liked {
+    color: #e74c3c;
+}
+
+/* Style cho cụm thông tin ngày tháng */
+.info-date-group {
+    margin-top: 4px;
+    line-height: 1.4;
+    border-top: 1px solid #eee;
+    padding-top: 4px;
+}
+
+.info-date-group .font-size-small {
+    font-size: 10px; /* Nhỏ hơn một chút để không chiếm diện tích */
+    display: flex;
+    align-items: center;
+}
+
+.info-date-group .font-size-small i {
+    margin-right: 4px;
+    width: 12px;
+}
+
+/* Giữ chiều cao thẻ ảnh đồng nhất */
+.list-item-desc {
+    padding: 10px 5px;
+    background: #fff;
+    min-height: 90px; /* Đảm bảo các thẻ đều nhau khi có thêm dòng ngày tháng */
+}
+
+/* Hiệu ứng hover cho thẻ ảnh */
+.list-item {
+    transition: transform 0.2s;
+    border: 1px solid transparent;
+}
+
+.list-item:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 4px 15px rgba(0,0,0,0.1);
+    border: 1px solid #ddd;
+    border-radius: 4px;
+}
+
+/* Trạng thái được chọn */
+.list-item.is-selected {
+    border: 2px solid #007bff;
+    background: #e7f1ff;
+}
+
+.list-item.is-selected .icon-check {
+    color: #007bff;
+    font-weight: 900; /* fas fa-check-square */
+}
+
+/* Overlay Tools cải tiến */
+.list-item-image-tools {
+    position: absolute;
+    display: flex;
+    gap: 8px;
+    padding: 6px;
+    background: rgba(0,0,0,0.4);
+    opacity: 0;
+    transition: opacity 0.2s;
+    z-index: 5;
+}
+
+.top-right { top: 0; right: 0; border-bottom-left-radius: 10px; }
+.--bottom.--right { bottom: 0; right: 0; border-top-left-radius: 10px; }
+
+/* Đảm bảo bar chọn hàng loạt luôn nổi */
+#bulk-actions-bar {
+    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+}
+
+.list-item-spreadsheet {
+    border-top: 1px dashed #ddd;
+    margin-top: 8px !important;
+    padding-top: 5px;
+    transition: all 0.2s;
+}
+
+.list-item-spreadsheet a {
+    text-decoration: none;
+    color: #555;
+}
+
+.list-item-spreadsheet:hover a {
+    color: #28a745; /* Đổi sang màu xanh lá khi hover */
+}

--- a/static/css/documents.css
+++ b/static/css/documents.css
@@ -3,49 +3,109 @@ body {
     background-color: #f4f7f6;
 }
 
-/* Container chính */
-.pad-content-listing {
-    width: 100%;
-    min-height: 1400px;
+/* Custom Grid 20% - 80% cho Desktop */
+@media (min-width: 992px) {
+    .col-custom-20 { flex: 0 0 20%; max-width: 20%; }
+    .col-custom-80 { flex: 0 0 80%; max-width: 80%; }
 }
 
-/* Wrapper cho ảnh để quản lý overlay */
+/* Cột Sidebar Sticky */
+.sidebar-spreadsheets {
+    max-height: 80vh;
+    overflow-y: auto;
+    border-radius: 8px;
+}
+
+.spreadsheet-filter-item {
+    cursor: pointer;
+    transition: all 0.2s;
+    border-left: 4px solid transparent;
+}
+
+.spreadsheet-filter-item:hover {
+    background-color: #f8f9fa;
+}
+
+.spreadsheet-filter-item.active {
+    background-color: #e7f1ff;
+    border-left-color: #7ebb5b;
+    color: #ec002c;
+}
+
+.spreadsheet-title-link {
+    color: #333;
+    font-weight: 600;
+    text-decoration: none !important;
+}
+
+.spreadsheet-title-link:hover {
+    color: #007bff;
+    text-decoration: underline !important;
+}
+
+.spreadsheet-actions {
+    display: flex;
+    opacity: 0.3;
+    transition: opacity 0.2s;
+}
+
+.spreadsheet-filter-item:hover .spreadsheet-actions {
+    opacity: 1;
+}
+
+.sidebar-spreadsheets::-webkit-scrollbar {
+    width: 6px;
+}
+.sidebar-spreadsheets::-webkit-scrollbar-thumb {
+    background-color: #cbd5e1;
+    border-radius: 10px;
+}
+.list-group-item.active {
+    border-color: #007bff;
+}
+.list-group-item.active .text-primary {
+    color: white !important;
+}
+
+/* Wrapper ảnh */
 .image-wrapper {
     position: relative;
-    background: #eee;
-    border-radius: 4px;
+    aspect-ratio: 1/1;
     overflow: hidden;
-    aspect-ratio: 1 / 1; /* Giữ ảnh vuông hoặc tỉ lệ nhất định */
+    background: #eee;
+    border-radius: 4px 4px 0 0;
 }
 
 .img-main {
     width: 100%;
     height: 100%;
     object-fit: cover;
-    display: block;
+    transition: transform 0.3s;
 }
 
-/* Tools chung */
+.list-item:hover .img-main {
+    transform: scale(1.05);
+}
+
+.font-size-small {
+    font-size: 11px;
+}
+
+/* Tools ảnh */
 .list-item-image-tools {
     position: absolute;
-    top: 0;
-    right: 0;
-    display: flex;
-    background: rgba(0, 0, 0, 0.5);
-    padding: 5px;
+    top: 5px;
+    right: 5px;
+    background: rgba(0,0,0,0.5);
+    border-radius: 4px;
+    padding: 3px 6px;
     opacity: 0;
-    transition: opacity 0.2s ease-in-out;
 }
 
-/* Hiện tools khi hover */
+.top-right { top: 0; right: 0; border-bottom-left-radius: 8px; }
+
 .list-item:hover .list-item-image-tools {
     opacity: 1;
-}
-
-/* Tool ở dưới */
-.list-item-image-tools.--bottom {
-    top: auto;
-    bottom: 0;
 }
 
 .btn-icon {
@@ -57,9 +117,27 @@ body {
     color: #3498db;
 }
 
+/* Tên SpreadSheet in hờ trên ảnh */
+.badge-spreadsheet-name {
+    position: absolute;
+    bottom: 8px;
+    left: 8px;
+    right: 8px;
+    background: rgba(0, 0, 0, 0.6);
+    color: white;
+    padding: 4px 8px;
+    border-radius: 4px;
+    font-size: 11px;
+    backdrop-filter: blur(2px);
+    z-index: 2;
+    pointer-events: none;
+}
+
 /* Mô tả dưới ảnh */
 .list-item-desc {
-    padding: 8px 2px;
+    padding: 10px 5px;
+    background: #fff;
+    min-height: 70px;
 }
 
 .list-item-desc-title-link {
@@ -68,26 +146,10 @@ body {
     color: #333;
     text-decoration: none;
 }
-
-.font-size-small {
-    font-size: 11px;
-    color: #777;
+.list-item-desc-title-link:hover {
+    color: #007bff;
 }
 
-/* Responsive Grid 6 cột */
-@media (min-width: 1200px) {
-    .col-xl-2 {
-        flex: 0 0 16.666667%;
-        max-width: 16.666667%;
-    }
-}
-
-/* Custom cho nút Like đã nhấn */
-.btn-liked {
-    color: #e74c3c;
-}
-
-/* Style cho cụm thông tin ngày tháng */
 .info-date-group {
     margin-top: 4px;
     line-height: 1.4;
@@ -96,37 +158,27 @@ body {
 }
 
 .info-date-group .font-size-small {
-    font-size: 10px; /* Nhỏ hơn một chút để không chiếm diện tích */
+    font-size: 11px;
+    color: #777;
     display: flex;
     align-items: center;
 }
 
-.info-date-group .font-size-small i {
-    margin-right: 4px;
-    width: 12px;
-}
-
-/* Giữ chiều cao thẻ ảnh đồng nhất */
-.list-item-desc {
-    padding: 10px 5px;
-    background: #fff;
-    min-height: 90px; /* Đảm bảo các thẻ đều nhau khi có thêm dòng ngày tháng */
-}
-
-/* Hiệu ứng hover cho thẻ ảnh */
+/* Hiệu ứng hover card */
 .list-item {
-    transition: transform 0.2s;
+    transition: transform 0.2s, box-shadow 0.2s;
     border: 1px solid transparent;
+    border-radius: 6px;
+    background: #fff;
 }
 
 .list-item:hover {
     transform: translateY(-3px);
     box-shadow: 0 4px 15px rgba(0,0,0,0.1);
     border: 1px solid #ddd;
-    border-radius: 4px;
 }
 
-/* Trạng thái được chọn */
+/* Trạng thái được chọn (áp dụng cho toàn bộ card thuộc SpreadSheet được chọn) */
 .list-item.is-selected {
     border: 2px solid #007bff;
     background: #e7f1ff;
@@ -134,41 +186,51 @@ body {
 
 .list-item.is-selected .icon-check {
     color: #007bff;
-    font-weight: 900; /* fas fa-check-square */
+    font-weight: 900;
 }
 
-/* Overlay Tools cải tiến */
-.list-item-image-tools {
-    position: absolute;
-    display: flex;
-    gap: 8px;
-    padding: 6px;
-    background: rgba(0,0,0,0.4);
-    opacity: 0;
-    transition: opacity 0.2s;
-    z-index: 5;
-}
-
-.top-right { top: 0; right: 0; border-bottom-left-radius: 10px; }
-.--bottom.--right { bottom: 0; right: 0; border-top-left-radius: 10px; }
-
-/* Đảm bảo bar chọn hàng loạt luôn nổi */
 #bulk-actions-bar {
-    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+    position: fixed;
+    bottom: 30px;
+    left: 50%;
+    transform: translateX(-50%) translateY(100px); /* Giấu bên dưới */
+    width: auto;
+    min-width: 350px;
+    z-index: 2000;
+    background: #2c3e50; /* Màu tối cho sang trọng */
+    color: white;
+    border: none;
+    border-radius: 50px; /* Bo tròn kiểu viên thuốc */
+    box-shadow: 0 10px 30px rgba(0,0,0,0.3);
+    transition: transform 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275), opacity 0.3s;
+    opacity: 0;
+    display: flex !important; /* Luôn là flex nhưng ẩn bằng opacity/transform */
+    padding: 10px 25px;
 }
 
-.list-item-spreadsheet {
-    border-top: 1px dashed #ddd;
-    margin-top: 8px !important;
-    padding-top: 5px;
-    transition: all 0.2s;
+#bulk-actions-bar.show {
+    transform: translateX(-50%) translateY(0);
+    opacity: 1;
 }
 
-.list-item-spreadsheet a {
-    text-decoration: none;
-    color: #555;
+#bulk-actions-bar .alert-info { background: transparent; border: none; color: white; margin: 0; padding: 0; }
+#bulk-actions-bar span { font-weight: 500; margin-right: 20px; }
+
+/* Hiệu ứng cho card khi được chọn */
+.gallery-card.is-selected .list-item {
+    border: 2px solid #3498db;
+    box-shadow: 0 0 15px rgba(52, 152, 219, 0.4);
+    transform: scale(0.98);
 }
 
-.list-item-spreadsheet:hover a {
-    color: #28a745; /* Đổi sang màu xanh lá khi hover */
+.empty-table-placeholder {
+    width: 100%;
+    height: 100%;
+    background: #f8f9fa;
+    border: 1px dashed #ced4da;
+    border-radius: 4px;
+}
+
+.list-item.is-selected .list-item-image-tools {
+    opacity: 1 !important;
 }

--- a/static/css/result_detail.css
+++ b/static/css/result_detail.css
@@ -92,6 +92,12 @@ body {
 #table-content-area {
     background: #fafafa;
     border: 1px solid #eee;
+    width: 100%;
+    max-height: 650px;        /* giữ nguyên */
+    height: 650px;            /* ← thêm dòng này để cố định chiều cao */
+    overflow-y: auto;         /* ← quan trọng nhất */
+    overflow-x: auto;         /* cuộn ngang nếu bảng rộng */
+    box-sizing: border-box;
 }
 
 /* Thanh công cụ trích xuất ngang */

--- a/static/js/documents.js
+++ b/static/js/documents.js
@@ -1,0 +1,284 @@
+// Hàm lấy CSRF Token từ Cookie (Dùng cho Django)
+function getCookie(name) {
+    var cookieValue = null;
+    if (document.cookie && document.cookie !== '') {
+        var cookies = document.cookie.split(';');
+        for (var i = 0; i < cookies.length; i++) {
+            var cookie = jQuery.trim(cookies[i]);
+            if (cookie.substring(0, name.length + 1) === (name + '=')) {
+                cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+                break;
+            }
+        }
+    }
+    return cookieValue;
+}
+var csrftoken = getCookie('csrftoken');
+
+// Cấu hình Ajax luôn gửi kèm CSRF Token
+$.ajaxSetup({
+    beforeSend: function(xhr, settings) {
+        if (!(/^http:.*/.test(settings.url) || /^https:.*/.test(settings.url))) {
+            xhr.setRequestHeader("X-CSRFToken", csrftoken);
+        }
+    }
+});
+
+$(document).ready(function() {
+
+    // 2. Xử lý nút Like (Toggle)
+    $('.list-item-like').on('click', function() {
+        var icon = $(this).find('span');
+        if (icon.hasClass('far')) {
+            icon.removeClass('far fa-heart').addClass('fas fa-heart btn-liked');
+        } else {
+            icon.removeClass('fas fa-heart btn-liked').addClass('far fa-heart');
+        }
+    });
+
+    // 3. Thanh tìm kiếm nhanh (Client-side)
+    $("#imageSearch").on("keyup", function() {
+        var value = $(this).val().toLowerCase();
+        $(".pad-content-listing .col-xl-2").filter(function() {
+            $(this).toggle($(this).text().toLowerCase().indexOf(value) > -1)
+        });
+    });
+
+    // 4. Các nút Edit/Share/Codes (Để trống URL như yêu cầu)
+    $('.tool-edit, .list-item-share, .tool-codes').on('click', function(e) {
+        // e.preventDefault(); // Uncomment nếu không muốn chuyển trang khi URL trống
+        console.log("Action triggered for ID:", $(this).closest('.list-item').data('id'));
+    });
+});
+
+$(document).ready(function() {
+    let selectedIds = [];
+
+    // 1. TRÌNH XEM ẢNH: ZOOM + SCROLL + CLICK OUTSIDE
+    let scale = 1;
+    const overlay = $(`
+        <div id="pv-overlay" style="display:none; position:fixed; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,0.9); z-index:9999; cursor:zoom-out; align-items:center; justify-content:center;">
+            <div id="pv-container" style="transition: transform 0.1s ease; cursor:default;">
+                <img id="pv-img" src="" style="max-width:90vw; max-height:90vh; border-radius:4px; box-shadow:0 0 20px rgba(0,0,0,0.5);">
+            </div>
+            <div style="position:fixed; bottom:20px; left:50%; transform:translateX(-50%); color:white; background:rgba(0,0,0,0.5); padding:5px 15px; border-radius:20px; pointer-events:none; font-size:12px;">
+                Cuộn chuột để Phóng to/Thu nhỏ | Click ra ngoài để đóng
+            </div>
+        </div>
+    `).appendTo('body');
+
+    $('.preview-trigger').on('click', function(e) {
+        e.stopPropagation();
+        const src = $(this).attr('src');
+        scale = 1;
+        $('#pv-img').attr('src', src);
+        $('#pv-container').css('transform', `scale(${scale})`);
+        overlay.css('display', 'flex').hide().fadeIn(200);
+    });
+
+    // Đóng khi ấn ra ngoài (vùng overlay)
+    overlay.on('click', function(e) {
+        if (e.target.id === 'pv-overlay' || e.target.id === 'pv-container') {
+            overlay.fadeOut(200);
+        }
+    });
+
+    // Phóng to/thu nhỏ bằng con lăn chuột
+    overlay.on('wheel', function(e) {
+        e.preventDefault();
+        const delta = e.originalEvent.deltaY;
+        if (delta > 0) {
+            if (scale > 0.5) scale -= 0.1; // Thu nhỏ
+        } else {
+            if (scale < 5) scale += 0.1; // Phóng to
+        }
+        $('#pv-container').css('transform', `scale(${scale})`);
+    });
+
+    // Ngăn chặn sự kiện click vào ảnh gây đóng overlay
+    $('#pv-img').on('click', function(e) {
+        e.stopPropagation();
+    });
+
+    // 2. Chọn hàng loạt (Toggle Selection)
+    $('.tool-select').on('click', function(e) {
+        e.stopPropagation();
+        const item = $(this).closest('.list-item');
+        const id = item.data('id');
+        const icon = $(this).find('span');
+
+        item.toggleClass('is-selected');
+
+        if (item.hasClass('is-selected')) {
+            selectedIds.push(id);
+            icon.removeClass('fa-square').addClass('fa-check-square');
+        } else {
+            selectedIds = selectedIds.filter(i => i !== id);
+            icon.removeClass('fa-check-square').addClass('fa-square');
+        }
+        updateBulkBar();
+    });
+
+    function updateBulkBar() {
+        if (selectedIds.length > 0) {
+            $('#bulk-actions-bar').removeClass('d-none');
+            $('#selected-count').text(selectedIds.length);
+        } else {
+            $('#bulk-actions-bar').addClass('d-none');
+        }
+    }
+
+    // 3. Xóa đơn lẻ với SweetAlert2
+    $('.tool-delete').on('click', function() {
+        const item = $(this).closest('.list-item');
+        const id = item.data('id');
+
+        Swal.fire({
+            title: 'Bạn có chắc chắn?',
+            text: "Dữ liệu này sẽ không thể khôi phục!",
+            icon: 'warning',
+            showCancelButton: true,
+            confirmButtonColor: '#d33',
+            cancelButtonColor: '#3085d6',
+            confirmButtonText: 'Vâng, xóa nó!'
+        }).then((result) => {
+            if (result.isConfirmed) {
+                // Giả lập gọi API xóa (Bạn thay bằng AJAX tới view bulk_delete_api)
+                $.post('/api/bulk-delete/', JSON.stringify({ids: [id]}), function() {
+                    item.fadeOut();
+                    Swal.fire('Đã xóa!', 'Tài liệu đã được gỡ bỏ.', 'success');
+                });
+            }
+        });
+    });
+
+    // Xóa hàng loạt
+    $('#btn-bulk-delete').on('click', function() {
+        Swal.fire({
+            title: `Xóa ${selectedIds.length} mục?`,
+            icon: 'danger',
+            showCancelButton: true,
+            confirmButtonText: 'Xóa tất cả'
+        }).then((result) => {
+            if (result.isConfirmed) {
+                // Ajax call tới view bulk_delete_api
+                console.log("Xóa list:", selectedIds);
+                location.reload(); // Reload để cập nhật UI
+            }
+        });
+    });
+
+    // 4. Copy Link (Share)
+    $('.list-item-share').on('click', function() {
+        const url = $(this).closest('.list-item').data('url');
+        navigator.clipboard.writeText(url).then(() => {
+            Swal.fire({
+                toast: true,
+                position: 'top-end',
+                icon: 'success',
+                title: 'Đã copy link ảnh!',
+                showConfirmButton: false,
+                timer: 1500
+            });
+        });
+    });
+
+    // 5. Tool Edit (Hiển thị Form nhỏ)
+    $('.tool-edit').on('click', function(e) {
+        e.stopPropagation();
+        const item = $(this).closest('.list-item');
+        const d = item.data(); // Lấy toàn bộ data attributes
+
+        Swal.fire({
+            title: '<i class="fas fa-file-alt"></i> Chi tiết tài liệu',
+            html: `
+                <div class="text-left border-top pt-3">
+                    <p class="mb-2"><strong><i class="fas fa-tag"></i> Tên:</strong> ${d.filename}</p>
+                    <p class="mb-2"><strong><i class="fas fa-fingerprint"></i> ID:</strong> #${d.id}</p>
+                    <p class="mb-2"><strong><i class="far fa-calendar-plus"></i> Ngày tạo:</strong> ${d.created}</p>
+                    <p class="mb-3"><strong><i class="fas fa-history"></i> Cập nhật:</strong> ${d.updated}</p>
+                    
+                    <div class="d-flex flex-column gap-2 mt-3">
+                        <a href="${d.url}" target="_blank" class="btn btn-outline-info btn-block mb-2">
+                            <i class="fas fa-external-link-alt"></i> Go to image online
+                        </a>
+                        <a href="${d.spreadsheetUrl}" class="btn btn-outline-success btn-block mb-2">
+                            <i class="fas fa-table"></i> Go to spreadsheet
+                        </a>
+                    </div>
+                </div>
+            `,
+            showCancelButton: true,
+            cancelButtonText: 'Đóng',
+            confirmButtonColor: '#007bff',
+            focusConfirm: false
+        }).then((result) => {
+
+        });
+    });
+
+    // 6. Tạo bảng tính trống (Bản hoàn chỉnh)
+    $('#btn-create-blank').on('click', function() {
+        Swal.fire({
+            title: 'Đặt tên bảng tính',
+            input: 'text',
+            inputPlaceholder: 'Ví dụ: Báo cáo tháng 4',
+            showCancelButton: true,
+            confirmButtonText: 'Tạo ngay',
+            cancelButtonText: 'Hủy',
+            inputValidator: (value) => {
+                if (!value) {
+                    return 'Bạn cần nhập tên bảng tính!';
+                }
+            }
+        }).then((result) => {
+            if (result.isConfirmed && result.value) {
+                const fileName = result.value;
+
+                // Hiển thị loading trong khi chờ Server xử lý
+                Swal.fire({
+                    title: 'Đang khởi tạo...',
+                    allowOutsideClick: false,
+                    didOpen: () => {
+                        Swal.showLoading();
+                    }
+                });
+
+                // Gửi AJAX tới Django
+                $.ajax({
+                    url: '/documents/create-blank/', // Đảm bảo URL này khớp với urls.py
+                    type: 'POST',
+                    data: {
+                        'name': fileName,
+                        'csrfmiddlewaretoken': '{{ csrf_token }}' // Lưu ý xem phần ghi chú bên dưới
+                    },
+                    success: function(response) {
+                        if (response.status === 'success') {
+                            Swal.fire({
+                                icon: 'success',
+                                title: 'Thành công!',
+                                text: 'Đang chuyển hướng tới bảng tính...',
+                                timer: 1500,
+                                showConfirmButton: false
+                            }).then(() => {
+                                // Chuyển hướng tới trang detail của bản ghi vừa tạo
+                                window.location.href = response.redirect_url;
+                            });
+                        } else {
+                            Swal.fire('Lỗi!', response.message || 'Không thể tạo bảng tính.', 'error');
+                        }
+                    },
+                    error: function() {
+                        Swal.fire('Lỗi kết nối!', 'Vui lòng kiểm tra lại đường truyền.', 'error');
+                    }
+                });
+            }
+        });
+    });
+
+    $('#btn-cancel-select').on('click', function() {
+        $('.list-item').removeClass('is-selected');
+        selectedIds = [];
+        updateBulkBar();
+    });
+});

--- a/static/js/documents.js
+++ b/static/js/documents.js
@@ -1,4 +1,4 @@
-// Hàm lấy CSRF Token từ Cookie (Dùng cho Django)
+// Hàm lấy CSRF Token từ Cookie
 function getCookie(name) {
     var cookieValue = null;
     if (document.cookie && document.cookie !== '') {
@@ -15,7 +15,6 @@ function getCookie(name) {
 }
 var csrftoken = getCookie('csrftoken');
 
-// Cấu hình Ajax luôn gửi kèm CSRF Token
 $.ajaxSetup({
     beforeSend: function(xhr, settings) {
         if (!(/^http:.*/.test(settings.url) || /^https:.*/.test(settings.url))) {
@@ -26,35 +25,106 @@ $.ajaxSetup({
 
 $(document).ready(function() {
 
-    // 2. Xử lý nút Like (Toggle)
-    $('.list-item-like').on('click', function() {
-        var icon = $(this).find('span');
-        if (icon.hasClass('far')) {
-            icon.removeClass('far fa-heart').addClass('fas fa-heart btn-liked');
+    // === LOGIC LỌC HÌNH ẢNH (MỚI) ===
+    $('.spreadsheet-filter-item, .spreadsheet-filter').on('click', function(e) {
+        // Nếu click vào thẻ <a> hoặc nút action thì không kích hoạt lọc ảnh ở đây
+        if ($(e.target).closest('.spreadsheet-title-link, .spreadsheet-actions').length) {
+            return;
+        }
+
+        const id = $(this).data('id');
+        $('.spreadsheet-filter-item, .spreadsheet-filter').removeClass('active');
+        $(this).addClass('active');
+
+        if (id === 'all') {
+            $('#gallery-header').text('Tất cả hình ảnh');
+            $('.gallery-card').fadeIn(200);
         } else {
-            icon.removeClass('fas fa-heart btn-liked').addClass('far fa-heart');
+            const title = $(this).find('.title-text').text();
+            $('#gallery-header').text('Ảnh từ: ' + title);
+            $('.gallery-card').hide();
+            $(`.gallery-card[data-spreadsheet-id="${id}"]`).fadeIn(200);
         }
     });
 
-    // 3. Thanh tìm kiếm nhanh (Client-side)
-    $("#imageSearch").on("keyup", function() {
-        var value = $(this).val().toLowerCase();
-        $(".pad-content-listing .col-xl-2").filter(function() {
-            $(this).toggle($(this).text().toLowerCase().indexOf(value) > -1)
+    // --- 2. SẮP XẾP SIDEBAR (Bảng tính) ---
+    $('.btn-sort-sidebar').on('click', function() {
+        const type = $(this).data('sort'); // 'updated', 'created', hoặc 'old'
+        const $list = $('#sidebar-list');
+        const items = $list.children('.spreadsheet-filter-item').get();
+
+        items.sort(function(a, b) {
+            let valA, valB;
+
+            if (type === 'updated') {
+                // Sắp xếp theo ngày cập nhật (Giảm dần)
+                valA = parseInt($(a).attr('data-updated')) || 0;
+                valB = parseInt($(b).attr('data-updated')) || 0;
+                return valB - valA;
+            } else if (type === 'created') {
+                // Sắp xếp theo ngày tạo (Giảm dần)
+                valA = parseInt($(a).attr('data-created')) || 0;
+                valB = parseInt($(b).attr('data-created')) || 0;
+                return valB - valA;
+            } else {
+                // Cũ nhất: Sắp xếp theo ngày tạo (Tăng dần)
+                valA = parseInt($(a).attr('data-created')) || 0;
+                valB = parseInt($(b).attr('data-created')) || 0;
+                return valA - valB;
+            }
+        });
+
+        // Cập nhật lại giao diện
+        $.each(items, function(i, li) {
+            $list.append(li);
+        });
+
+        // Đổi màu nút trạng thái Active
+        $('.btn-sort-sidebar').removeClass('btn-secondary text-white').addClass('btn-outline-secondary');
+        $(this).removeClass('btn-outline-secondary').addClass('btn-secondary text-white');
+    });
+
+    // --- 3. SẮP XẾP GALLERY (Ảnh 80%) ---
+    $('.btn-sort-gallery').on('click', function() {
+        const type = $(this).data('sort');
+        const $gallery = $('#image-gallery');
+        const items = $gallery.children('.gallery-card').get();
+
+        items.sort(function(a, b) {
+            const tsA = parseInt($(a).data('timestamp'));
+            const tsB = parseInt($(b).data('timestamp'));
+            return type === 'new' ? tsB - tsA : tsA - tsB;
+        });
+
+        $.each(items, function(i, card) { $gallery.append(card); });
+        $('.btn-sort-gallery').removeClass('btn-primary').addClass('btn-outline-primary');
+        $(this).removeClass('btn-outline-primary').addClass('btn-primary');
+    });
+
+    // --- 4. CHỈNH SỬA TIÊU ĐỀ (Edit Title) ---
+    $('.btn-edit-title').on('click', function(e) {
+        e.stopPropagation();
+        const id = $(this).data('id');
+        const oldTitle = $(this).data('title');
+
+        Swal.fire({
+            title: 'Đổi tên bảng tính',
+            input: 'text',
+            inputValue: oldTitle,
+            showCancelButton: true,
+            confirmButtonText: 'Lưu thay đổi',
+            cancelButtonText: 'Hủy'
+        }).then((result) => {
+            if (result.isConfirmed && result.value) {
+                // Gọi AJAX cập nhật title ở đây
+                $.post(`/api/update-title/${id}/`, { title: result.value }, function(res) {
+                    location.reload(); // Hoặc cập nhật DOM tại chỗ
+                });
+            }
         });
     });
 
-    // 4. Các nút Edit/Share/Codes (Để trống URL như yêu cầu)
-    $('.tool-edit, .list-item-share, .tool-codes').on('click', function(e) {
-        // e.preventDefault(); // Uncomment nếu không muốn chuyển trang khi URL trống
-        console.log("Action triggered for ID:", $(this).closest('.list-item').data('id'));
-    });
-});
-
-$(document).ready(function() {
-    let selectedIds = [];
-
-    // 1. TRÌNH XEM ẢNH: ZOOM + SCROLL + CLICK OUTSIDE
+    // === TRÌNH XEM ẢNH ZOMM ===
     let scale = 1;
     const overlay = $(`
         <div id="pv-overlay" style="display:none; position:fixed; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,0.9); z-index:9999; cursor:zoom-out; align-items:center; justify-content:center;">
@@ -76,148 +146,210 @@ $(document).ready(function() {
         overlay.css('display', 'flex').hide().fadeIn(200);
     });
 
-    // Đóng khi ấn ra ngoài (vùng overlay)
     overlay.on('click', function(e) {
         if (e.target.id === 'pv-overlay' || e.target.id === 'pv-container') {
             overlay.fadeOut(200);
         }
     });
 
-    // Phóng to/thu nhỏ bằng con lăn chuột
     overlay.on('wheel', function(e) {
         e.preventDefault();
         const delta = e.originalEvent.deltaY;
         if (delta > 0) {
-            if (scale > 0.5) scale -= 0.1; // Thu nhỏ
+            if (scale > 0.5) scale -= 0.1;
         } else {
-            if (scale < 5) scale += 0.1; // Phóng to
+            if (scale < 5) scale += 0.1;
         }
         $('#pv-container').css('transform', `scale(${scale})`);
     });
 
-    // Ngăn chặn sự kiện click vào ảnh gây đóng overlay
-    $('#pv-img').on('click', function(e) {
+    $('#pv-img').on('click', function(e) { e.stopPropagation(); });
+
+
+    // --- 1. XEM CHI TIẾT ẢNH ---
+    $('.tool-img-info').on('click', function(e) {
         e.stopPropagation();
+        const container = $(this).closest('.gallery-card');
+        const d = container.data();
+        // Chuyển đổi size sang KB/MB cho dễ đọc
+        const sizeFormatted = d.size > 1024 * 1024
+            ? (d.size / (1024 * 1024)).toFixed(2) + ' MB'
+            : (d.size / 1024).toFixed(2) + ' KB';
+
+        Swal.fire({
+            title: '<i class="fas fa-image text-primary"></i> Chi tiết hình ảnh',
+            html: `
+                <div class="text-left border-top pt-3" style="font-size: 14px;">
+                    <p class="mb-2"><strong>Tên file:</strong> ${d.filename}</p>
+                    <p class="mb-2"><strong>Định dạng:</strong> ${d.mimeType || 'Không xác định'}</p>
+                    <p class="mb-2"><strong>Dung lượng:</strong> ${sizeFormatted}</p>
+                    <p class="mb-2"><strong>Ngày tải lên:</strong> ${d.uploaded}</p>
+                    <p class="mb-3 text-truncate"><strong>URL:</strong> <a href="${d.url}" target="_blank">${d.url}</a></p>
+                    <div class="text-center">
+                        <img src="${d.url}" style="max-width: 100%; max-height: 200px; border-radius: 8px; border: 1px solid #ddd;">
+                    </div>
+                </div>
+            `,
+            showCancelButton: false,
+            confirmButtonText: 'Đóng',
+            confirmButtonColor: '#6c757d'
+        });
     });
 
-    // 2. Chọn hàng loạt (Toggle Selection)
-    $('.tool-select').on('click', function(e) {
+    let selectedImageIds = new Set();
+
+    // --- 2. CHỌN ẢNH (SINGLE & BULK) ---
+    // --- 2. CHỌN ẢNH (ĐÃ FIX LOGIC) ---
+    $('.tool-img-select').on('click', function(e) {
         e.stopPropagation();
-        const item = $(this).closest('.list-item');
-        const id = item.data('id');
-        const icon = $(this).find('span');
 
-        item.toggleClass('is-selected');
+        // SỬA: Lấy từ gallery-card để có ID chuẩn
+        const card = $(this).closest('.gallery-card');
+        const imgId = card.data('img-id');
+        const icon = $(this).find('.icon-check-img');
 
-        if (item.hasClass('is-selected')) {
-            selectedIds.push(id);
-            icon.removeClass('fa-square').addClass('fa-check-square');
-        } else {
-            selectedIds = selectedIds.filter(i => i !== id);
-            icon.removeClass('fa-check-square').addClass('fa-square');
+        // KIỂM TRA LOGIC: Nếu imgId bị undefined, báo lỗi ngay để debug
+        if (imgId === undefined) {
+            console.error("Lỗi: Không tìm thấy data-img-id trên .gallery-card");
+            return;
         }
-        updateBulkBar();
+
+        if (selectedImageIds.has(imgId)) {
+            selectedImageIds.delete(imgId);
+            card.removeClass('is-selected');
+            icon.removeClass('fa-check-square text-primary').addClass('fa-square');
+        } else {
+            selectedImageIds.add(imgId);
+            card.addClass('is-selected');
+            icon.removeClass('fa-square').addClass('fa-check-square text-primary');
+        }
+
+        updateImageBulkBar();
     });
 
-    function updateBulkBar() {
-        if (selectedIds.length > 0) {
-            $('#bulk-actions-bar').removeClass('d-none');
-            $('#selected-count').text(selectedIds.length);
+    function updateImageBulkBar() {
+        const count = selectedImageIds.size;
+        const $bar = $('#bulk-actions-bar');
+
+        if (count > 0) {
+            $('#selected-count').text(count);
+            $bar.addClass('show'); // Dùng class show thay vì d-none
         } else {
-            $('#bulk-actions-bar').addClass('d-none');
+            $bar.removeClass('show');
         }
     }
 
-    // 3. Xóa đơn lẻ với SweetAlert2
-    $('.tool-delete').on('click', function() {
-        const item = $(this).closest('.list-item');
-        const id = item.data('id');
+    // Hủy chọn
+    $('#btn-cancel-select').on('click', function() {
+        selectedImageIds.clear();
+        $('.gallery-card').removeClass('is-selected');
+        $('.icon-check-img').removeClass('fa-check-square text-primary').addClass('fa-square');
+        updateImageBulkBar();
+    });
+
+    // --- 3. XÓA ẢNH (ĐƠN LẺ) ---
+    $('.tool-img-delete').on('click', function(e) {
+        e.stopPropagation();
+        const card = $(this).closest('.gallery-card');
+        const imgId = card.data('img-id');
 
         Swal.fire({
-            title: 'Bạn có chắc chắn?',
-            text: "Dữ liệu này sẽ không thể khôi phục!",
+            title: 'Xóa ảnh này?',
             icon: 'warning',
             showCancelButton: true,
-            confirmButtonColor: '#d33',
-            cancelButtonColor: '#3085d6',
-            confirmButtonText: 'Vâng, xóa nó!'
+            confirmButtonText: 'Xóa'
         }).then((result) => {
             if (result.isConfirmed) {
-                // Giả lập gọi API xóa (Bạn thay bằng AJAX tới view bulk_delete_api)
-                $.post('/api/bulk-delete/', JSON.stringify({ids: [id]}), function() {
-                    item.fadeOut();
-                    Swal.fire('Đã xóa!', 'Tài liệu đã được gỡ bỏ.', 'success');
+                $.post(`/api/delete-image/${imgId}/`, function() {
+                    card.fadeOut(300, function() { $(this).remove(); });
+                    selectedImageIds.delete(imgId);
+                    updateImageBulkBar();
                 });
             }
         });
     });
 
-    // Xóa hàng loạt
+    // --- 4. XÓA ẢNH HÀNG LOẠT ---
     $('#btn-bulk-delete').on('click', function() {
+        const idsArray = Array.from(selectedImageIds);
+
         Swal.fire({
-            title: `Xóa ${selectedIds.length} mục?`,
+            title: `Xóa ${idsArray.length} ảnh đã chọn?`,
+            text: "Hành động này không thể hoàn tác!",
             icon: 'danger',
             showCancelButton: true,
+            confirmButtonColor: '#d33',
             confirmButtonText: 'Xóa tất cả'
         }).then((result) => {
             if (result.isConfirmed) {
-                // Ajax call tới view bulk_delete_api
-                console.log("Xóa list:", selectedIds);
-                location.reload(); // Reload để cập nhật UI
+                $.ajax({
+                    url: '/api/bulk-delete-images/', // Cập nhật URL API của bạn
+                    type: 'POST',
+                    data: JSON.stringify({ ids: idsArray }),
+                    contentType: 'application/json',
+                    success: function() {
+                        location.reload();
+                    },
+                    error: function() {
+                        Swal.fire('Lỗi!', 'Có lỗi xảy ra khi xóa hàng loạt.', 'error');
+                    }
+                });
             }
         });
     });
 
-    // 4. Copy Link (Share)
-    $('.list-item-share').on('click', function() {
-        const url = $(this).closest('.list-item').data('url');
-        navigator.clipboard.writeText(url).then(() => {
-            Swal.fire({
-                toast: true,
-                position: 'top-end',
-                icon: 'success',
-                title: 'Đã copy link ảnh!',
-                showConfirmButton: false,
-                timer: 1500
-            });
+    // --- 5. XÓA BẢNG TÍNH ---
+    $('.btn-delete-res').on('click', function(e) {
+        e.stopPropagation();
+        const id = $(this).data('id');
+
+        Swal.fire({
+            title: 'Xóa bảng tính này?',
+            text: "Dữ liệu bảng và liên kết ảnh sẽ mất, nhưng ảnh gốc vẫn còn trong kho.",
+            icon: 'warning',
+            showCancelButton: true,
+            confirmButtonColor: '#d33',
+            confirmButtonText: 'Xóa ngay'
+        }).then((result) => {
+            if (result.isConfirmed) {
+                // Gọi AJAX xóa
+                $.post(`/api/delete-result/${id}/`, function() {
+                    $(`.spreadsheet-filter-item[data-id="${id}"]`).remove();
+                    $(`.gallery-card[data-spreadsheet-id="${id}"]`).remove();
+                    Swal.fire('Đã xóa!', '', 'success');
+                });
+            }
         });
     });
 
-    // 5. Tool Edit (Hiển thị Form nhỏ)
+    // === XEM THÔNG TIN LẺ ===
     $('.tool-edit').on('click', function(e) {
         e.stopPropagation();
-        const item = $(this).closest('.list-item');
-        const d = item.data(); // Lấy toàn bộ data attributes
+        const d = $(this).closest('.list-item').data();
 
         Swal.fire({
             title: '<i class="fas fa-file-alt"></i> Chi tiết tài liệu',
             html: `
                 <div class="text-left border-top pt-3">
-                    <p class="mb-2"><strong><i class="fas fa-tag"></i> Tên:</strong> ${d.filename}</p>
-                    <p class="mb-2"><strong><i class="fas fa-fingerprint"></i> ID:</strong> #${d.id}</p>
+                    <p class="mb-2"><strong><i class="fas fa-tag"></i> Tên ảnh/Bảng:</strong> ${d.filename}</p>
+                    <p class="mb-2"><strong><i class="fas fa-fingerprint"></i> ID Bảng:</strong> #${d.id}</p>
                     <p class="mb-2"><strong><i class="far fa-calendar-plus"></i> Ngày tạo:</strong> ${d.created}</p>
                     <p class="mb-3"><strong><i class="fas fa-history"></i> Cập nhật:</strong> ${d.updated}</p>
                     
                     <div class="d-flex flex-column gap-2 mt-3">
-                        <a href="${d.url}" target="_blank" class="btn btn-outline-info btn-block mb-2">
-                            <i class="fas fa-external-link-alt"></i> Go to image online
-                        </a>
                         <a href="${d.spreadsheetUrl}" class="btn btn-outline-success btn-block mb-2">
-                            <i class="fas fa-table"></i> Go to spreadsheet
+                            <i class="fas fa-table"></i> Đi tới trang bảng tính
                         </a>
                     </div>
                 </div>
             `,
             showCancelButton: true,
             cancelButtonText: 'Đóng',
-            confirmButtonColor: '#007bff',
-            focusConfirm: false
-        }).then((result) => {
-
+            showConfirmButton: false
         });
     });
 
-    // 6. Tạo bảng tính trống (Bản hoàn chỉnh)
+    // === TẠO BẢNG TRỐNG ===
     $('#btn-create-blank').on('click', function() {
         Swal.fire({
             title: 'Đặt tên bảng tính',
@@ -227,58 +359,33 @@ $(document).ready(function() {
             confirmButtonText: 'Tạo ngay',
             cancelButtonText: 'Hủy',
             inputValidator: (value) => {
-                if (!value) {
-                    return 'Bạn cần nhập tên bảng tính!';
-                }
+                if (!value) return 'Bạn cần nhập tên bảng tính!';
             }
         }).then((result) => {
             if (result.isConfirmed && result.value) {
-                const fileName = result.value;
-
-                // Hiển thị loading trong khi chờ Server xử lý
                 Swal.fire({
                     title: 'Đang khởi tạo...',
                     allowOutsideClick: false,
-                    didOpen: () => {
-                        Swal.showLoading();
-                    }
+                    didOpen: () => { Swal.showLoading(); }
                 });
 
-                // Gửi AJAX tới Django
                 $.ajax({
-                    url: '/documents/create-blank/', // Đảm bảo URL này khớp với urls.py
+                    url: '/documents/create-blank/',
                     type: 'POST',
-                    data: {
-                        'name': fileName,
-                        'csrfmiddlewaretoken': '{{ csrf_token }}' // Lưu ý xem phần ghi chú bên dưới
-                    },
+                    data: { 'name': result.value },
                     success: function(response) {
                         if (response.status === 'success') {
-                            Swal.fire({
-                                icon: 'success',
-                                title: 'Thành công!',
-                                text: 'Đang chuyển hướng tới bảng tính...',
-                                timer: 1500,
-                                showConfirmButton: false
-                            }).then(() => {
-                                // Chuyển hướng tới trang detail của bản ghi vừa tạo
-                                window.location.href = response.redirect_url;
-                            });
+                            window.location.href = response.redirect_url;
                         } else {
                             Swal.fire('Lỗi!', response.message || 'Không thể tạo bảng tính.', 'error');
                         }
                     },
-                    error: function() {
-                        Swal.fire('Lỗi kết nối!', 'Vui lòng kiểm tra lại đường truyền.', 'error');
+                    error: function(xhr) {
+                        Swal.fire('Lỗi kết nối!', 'Vui lòng kiểm tra lại.', 'error');
                     }
                 });
             }
         });
     });
 
-    $('#btn-cancel-select').on('click', function() {
-        $('.list-item').removeClass('is-selected');
-        selectedIds = [];
-        updateBulkBar();
-    });
 });

--- a/static/js/home.js
+++ b/static/js/home.js
@@ -1,3 +1,4 @@
+window.originalFileName = "";
 document.addEventListener('DOMContentLoaded', function() {
     const fileInput = document.getElementById('id_file');
     const selectBtn = document.getElementById('selectBtn'); // Nút chọn/đổi ảnh
@@ -18,28 +19,27 @@ document.addEventListener('DOMContentLoaded', function() {
         if (this.files && this.files[0]) {
             const file = this.files[0];
 
-            // Hiển thị tên file
+            // LƯU TÊN FILE GỐC VÀO BIẾN TOÀN CỤC TẠI ĐÂY
+            window.originalFileName = this.files[0].name; // Cập nhật vào window
+
+            // Hiển thị tên file trên giao diện
             fileNameDisplay.innerText = "📄 File: " + file.name;
 
             const reader = new FileReader();
             reader.onload = function(e) {
                 imagePreview.src = e.target.result;
-
-                // Hiện khung preview, ẩn placeholder
                 previewContainer.style.display = 'block';
                 previewPlaceholder.style.display = 'none';
-
-                // Cuộn xuống nhẹ để người dùng thấy ảnh nếu màn hình nhỏ
                 previewContainer.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
             };
             reader.readAsDataURL(file);
         }
     });
 
-    // 3. Khi nhấn nút "Bắt đầu trích xuất" (nút dưới ảnh)
+    // 3. Khi nhấn nút "Bắt đầu trích xuất"
     extractBtn.addEventListener('click', function() {
         if (fileInput.files && fileInput.files[0]) {
-            // Gọi hàm initEditor từ file image_handler.js
+            // Khi gọi initEditor, biến originalFileName đã có giá trị tên file gốc
             initEditor(fileInput);
         } else {
             Swal.fire('Thông báo', 'Vui lòng chọn ảnh trước!', 'info');
@@ -117,18 +117,24 @@ document.addEventListener('click', function(e) {
 });
 
 /**
- * Hàm gọi khi hoàn tất Crop ảnh (giữ nguyên logic cũ của bạn)
+ * Hàm gọi khi hoàn tất Crop ảnh từ Trang chủ (Tạo bảng mới)
+ * Đã cập nhật logic kiểm tra hạn mức 50 ảnh.
  */
-function onImageCropped(blob, languagesStr) {
+function onImageCropped(blob, languagesStr, originalFileName) {
     const formData = new FormData();
     formData.append('file', blob, "processed_image.jpg");
-    formData.append('save_db', 'true');
 
+    // Đảm bảo tên file không bị rỗng nếu có sự cố
+    const finalName = originalFileName || "image_" + Date.now() + ".jpg";
+    formData.append('original_filename', finalName);    formData.append('save_db', 'true'); // Yêu cầu backend tạo mới ExtractedResult và lưu UploadedFile
+
+    formData.append('mime_type', blob.type);
     // Gắn chuỗi ngôn ngữ vào form data
-    formData.append('languages', languagesStr || 'all')
+    formData.append('languages', languagesStr || 'all');
 
     const csrftoken = document.querySelector('[name=csrfmiddlewaretoken]').value;
 
+    // Hiển thị trạng thái đang xử lý
     Swal.fire({
         title: 'Đang xử lý...',
         text: 'AI đang phân tích bảng biểu...',
@@ -144,14 +150,38 @@ function onImageCropped(blob, languagesStr) {
     .then(response => response.json())
     .then(data => {
         Swal.close();
+
+        // 1. Xử lý khi thành công
         if (data.status === 'success') {
             window.location.href = "/result/" + data.result_id + "/";
-        } else {
-            Swal.fire('Lỗi AI', data.message, 'error');
+        }
+
+        // 2. Xử lý khi kho lưu trữ 50 ảnh đã đầy
+        else if (data.status === 'limit_exceeded') {
+            Swal.fire({
+                title: 'Kho lưu trữ đầy!',
+                text: data.message, // Thông báo từ backend: "Kho lưu trữ ảnh đã đầy (50/50)..."
+                icon: 'warning',
+                showCancelButton: true,
+                confirmButtonColor: '#3085d6',
+                cancelButtonColor: '#d33',
+                confirmButtonText: 'Dọn dẹp ngay',
+                cancelButtonText: 'Để sau'
+            }).then((result) => {
+                if (result.isConfirmed) {
+                    // Điều hướng người dùng đến trang quản lý tài liệu để xóa ảnh
+                    window.location.href = data.redirect_url;
+                }
+            });
+        }
+
+        // 3. Xử lý các lỗi khác (AI fail, định dạng file...)
+        else {
+            Swal.fire('Lỗi hệ thống', data.message, 'error');
         }
     })
     .catch(error => {
         Swal.close();
-        Swal.fire('Lỗi', 'Không thể kết nối máy chủ.', 'error');
+        Swal.fire('Lỗi kết nối', 'Không thể kết nối máy chủ. Vui lòng thử lại.', 'error');
     });
 }

--- a/static/js/image_handler.js
+++ b/static/js/image_handler.js
@@ -97,8 +97,7 @@ function processAndExtract() {
 
         // GỌI HÀM CALLBACK: Hàm này phải được định nghĩa trong home.js hoặc result_detail.js
         if (typeof onImageCropped === 'function') {
-            onImageCropped(blob, languagesStr);
-        } else {
+            onImageCropped(blob, languagesStr, window.originalFileName || "unknown_part.jpg");        } else {
             console.error("Lỗi: Hàm onImageCropped(blob) chưa được định nghĩa!");
         }
 

--- a/static/js/result_detail.js
+++ b/static/js/result_detail.js
@@ -1,28 +1,38 @@
 // Thêm biến toàn cục để quản lý thời gian chờ
 let autosaveTimeout = null;
 document.addEventListener("DOMContentLoaded", function() {
-        var rawData = window.DJANGO_TABLE_DATA || [['', '', '', '']];
+    var rawData = window.DJANGO_TABLE_DATA || [['', '', '', '']];
     var spreadsheetDiv = document.getElementById('spreadsheet');
     if (spreadsheetDiv) {
         window.mySpreadsheet = jspreadsheet(spreadsheetDiv, {
             data: rawData,
-            minDimensions: [10, 22  ],
+            minDimensions: [10, 22],
             defaultColWidth: 120,
-            tableOverflow: true,
-            tableWidth: "100%",
-            tableHeight: "600px",
-            allowInsertRow: true, // Cho phép thêm dòng
-            allowInsertColumn: true, // Cho phép thêm cột
+            // tableOverflow: true,
+            tableWidth: "100%",        // ← sửa lại, bỏ khoảng trắng thừa
+            tableHeight: "600px",      // giữ nguyên hoặc tăng lên 620px cũng được
+            allowInsertRow: true,
+            allowInsertColumn: true,
             search: true,
             columnSorting: true,
-            onchange: function() {
-                // Kích hoạt tự động lưu khi có bất kỳ thay đổi nào
-                triggerAutoSave();
-            },
+            freezeColumns: 0,
+            onchange: function() { triggerAutoSave(); },
             oninsertrow: triggerAutoSave,
             oninsertcolumn: triggerAutoSave,
             ondeleterow: triggerAutoSave,
             ondeletecolumn: triggerAutoSave
+        });
+    }
+
+    // BỔ SUNG: Lắng nghe sự kiện chọn ảnh để lưu tên file gốc
+    const picUpload = document.getElementById('pic-upload');
+    if (picUpload) {
+        picUpload.addEventListener('change', function() {
+            if (this.files && this.files[0]) {
+                // Lưu tên file vào biến toàn cục để image_handler.js có thể lấy được
+                window.originalFileName = this.files[0].name;
+                console.log("Đã lưu tên file gốc tại detail:", window.originalFileName);
+            }
         });
     }
 });
@@ -162,9 +172,10 @@ function parseCoords(cellStr) {
 
 
 /**
- * Hàm Callback đã sửa lỗi để hiển thị được lên bảng
+ * Hàm xử lý khi Generate thêm dữ liệu vào một ô cụ thể trong bảng hiện tại
+ * Đã cập nhật để gửi result_id và kiểm tra giới hạn 50 ảnh
  */
-async function onImageCropped(blob) {
+async function onImageCropped(blob, languagesStr, originalFileName) {
     // 1. Hỏi tọa độ (Kết quả trả về là STRING, ví dụ: "A1")
     const { value: targetCoordsStr } = await Swal.fire({
         title: 'Chọn ô bắt đầu',
@@ -183,26 +194,33 @@ async function onImageCropped(blob) {
 
     if (!targetCoordsStr) return;
 
-    // --- BƯỚC QUAN TRỌNG: CHUYỂN STRING THÀNH OBJECT ---
+    // --- CHUYỂN STRING THÀNH OBJECT TOẠ ĐỘ ---
     const coordsObj = parseCoords(targetCoordsStr);
-    // --------------------------------------------------
 
     // 2. Hiển thị Loading
     Swal.fire({
         title: 'Đang xử lý...',
-        text: 'Đang phân tích vùng ảnh đã cắt',
+        text: 'AI đang phân tích vùng ảnh đã chọn',
         allowOutsideClick: false,
         didOpen: () => { Swal.showLoading(); }
     });
 
-    // 3. Chuẩn bị dữ liệu
+    // 3. Chuẩn bị dữ liệu gửi lên Backend
     const formData = new FormData();
     formData.append('file', blob, 'extracted_part.jpg');
+    formData.append('original_filename', originalFileName);
+    // Đặt là 'false' để backend biết đây là flow cập nhật bản nháp (Flow 2)
     formData.append('save_db', 'false');
+
+    // GỬI KÈM ID CỦA BẢNG HIỆN TẠI ĐỂ LƯU VẾT ẢNH VÀO source_file_ids
+    // Giả sử bạn lưu ID của result hiện tại vào biến global CURRENT_RESULT_ID
+    formData.append('result_id', window.CURRENT_RESULT_ID);
+
+    formData.append('languages', languagesStr || 'all');
 
     const csrftoken = document.querySelector('[name=csrfmiddlewaretoken]').value;
 
-    // 4. Gửi Request
+    // 4. Gửi Request tới API dùng chung
     fetch("/extract-only-api/", {
         method: 'POST',
         headers: { 'X-CSRFToken': csrftoken },
@@ -212,11 +230,12 @@ async function onImageCropped(blob) {
     .then(data => {
         Swal.close();
 
+        // TRƯỜNG HỢP 1: Thành công
         if (data.status === 'success') {
-            // 5. CẬP NHẬT GIAO DIỆN: Dùng coordsObj đã parse thay vì targetCoordsStr
+            // Cập nhật dữ liệu lên giao diện bảng
             updateTableDisplay(data.table, coordsObj);
 
-            // Kích hoạt tự động lưu nháp
+            // Tự động lưu bản nháp vào ExtractedResult.table_data_draft
             triggerAutoSave();
 
             const Toast = Swal.mixin({
@@ -226,10 +245,28 @@ async function onImageCropped(blob) {
                 timer: 3000,
                 timerProgressBar: true
             });
-            Toast.fire({ icon: 'success', title: 'Đã chèn dữ liệu thành công!' });
+            Toast.fire({ icon: 'success', title: 'Đã chèn dữ liệu và lưu vết ảnh!' });
+        }
 
-        } else {
-            Swal.fire({ icon: 'error', title: 'Không thể trích xuất', text: data.message });
+        // TRƯỜNG HỢP 2: Kho lưu trữ 50 ảnh đã đầy
+        else if (data.status === 'limit_exceeded') {
+            Swal.fire({
+                title: 'Kho lưu trữ đầy!',
+                text: data.message,
+                icon: 'warning',
+                showCancelButton: true,
+                confirmButtonText: 'Đến trang dọn dẹp',
+                cancelButtonText: 'Đóng'
+            }).then((result) => {
+                if (result.isConfirmed) {
+                    window.location.href = data.redirect_url; // Điều hướng đến Documents để xóa ảnh
+                }
+            });
+        }
+
+        // TRƯỜNG HỢP 3: Các lỗi khác (AI, server...)
+        else {
+            Swal.fire({ icon: 'error', title: 'Lỗi', text: data.message });
         }
     })
     .catch(err => {


### PR DESCRIPTION
### 🚀 Detail (Chi tiết thay đổi):
- Cập nhật Navigation: Đổi "Hồ sơ của tôi" thành "Tài liệu của tôi" trên Navbar để phù hợp với định hướng quản lý dữ liệu tập trung.
- Tái cấu trúc Database (Decoupling): Tách rời UploadedFile và ExtractedResult. Hiện tại, ExtractedResult không còn phụ thuộc cứng vào một ForeignKey của ảnh mà liên kết trực tiếp với User.
- Hỗ trợ Đa nguồn (Multi-source): Thêm trường source_file_ids (ListField) vào ExtractedResult, cho phép một bảng dữ liệu được tạo từ 0 ảnh (Bảng trống), 1 ảnh, hoặc nhiều ảnh gộp lại.
- Quản lý hạn mức (Media Quota): Triển khai logic kiểm tra hạn mức 50 ảnh/người dùng. Hệ thống sẽ chặn upload và yêu cầu người dùng tự dọn dẹp Media Library khi đạt giới hạn thay vì tự động xóa, giúp bảo vệ dữ liệu bằng chứng của người dùng.
- Tính năng Bảng trống: Bổ sung chức năng khởi tạo Worksheet trắng trực tiếp từ giao diện Documents mà không cần upload ảnh mồi.

### 🔗 Relative (Liên kết Issue):
- Giải quyết: #52 (Tách biệt logic Image và Data)
- Giải quyết: #53 (Quản lý Quota người dùng)

### ✅ Resolved Problems (Các vấn đề đã giải quyết):
- Về ERD User: Quyết định sử dụng model User mặc định của Django để đảm bảo tính ổn định và bảo mật, kết hợp với UsageLog để theo dõi tần suất sử dụng.
- Về việc tách bảng Ảnh: Đã tách riêng UploadedFile thành một "Media Library". Điều này giải quyết triệt để lỗi khi tạo bảng trống (không có image_url) và hỗ trợ lưu vết nhiều ảnh cho một tài liệu.
- Về ảnh đại diện tài liệu: Thay vì lấy một ảnh upload làm đại diện (không khả thi cho bảng nhiều ảnh hoặc bảng trống), giao diện hiện tại sẽ sử dụng Icon định dạng tài liệu hoặc Snippet nội dung bảng để làm thumbnail trên trang danh sách

## Conclude: Giải quyết #52 và **GỘP**